### PR TITLE
Work around NuGet path issue

### DIFF
--- a/sample/nuget.config
+++ b/sample/nuget.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="FunctionsSdkPath" value="..\src\Microsoft.NET.Sdk.Functions\bin\Release" />
+    <add key="FunctionsSdkPath" value="../src/Microsoft.NET.Sdk.Functions/bin/Release" />
     <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v2" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Forward slashes as path separators should work on Windows, but
backslashes don't work on Unix.