### PR TITLE
Moving all the publish contents outside bin

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.targets
@@ -61,7 +61,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   
   <Target Name="_InitPublishBinDirectory" >
     <PropertyGroup>
-      <PublishDir>$(PublishIntermediateOutputPath)\bin</PublishDir>
+      <PublishDir>$(PublishIntermediateOutputPath)</PublishDir>
     </PropertyGroup>
 
     <!-- Remove all the files from the temp directory first-->


### PR DESCRIPTION
@ahmelsayed @lindydonna 

Work-around to make publishing the content files work. Permanent fix would be to identify the binaries and move them to bin and copy the rest outside.
