### PR TITLE
Support for DisableAttribute overloads

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions/MakeFunction/FunctionJsonSchema.cs
+++ b/src/Microsoft.NET.Sdk.Functions/MakeFunction/FunctionJsonSchema.cs
@@ -10,7 +10,7 @@ namespace MakeFunctionJson
         public IEnumerable<JObject> Bindings { get; set; }
 
         [JsonProperty("disabled")]
-        public bool Disabled { get; set; }
+        public object Disabled { get; set; }
 
         [JsonProperty("scriptFile")]
         public string ScriptFile { get; set; }

--- a/src/Microsoft.NET.Sdk.Functions/MakeFunction/MethodInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions/MakeFunction/MethodInfoExtensions.cs
@@ -71,7 +71,7 @@ namespace MakeFunctionJson
                 ScriptFile = assemblyPath,
                 // A method is disabled is any of it's parameters have [Disabled] attribute
                 // or if the method itself or class have the [Disabled] attribute.
-                Disabled = method.IsDisabled()
+                Disabled = method.GetDisabled()
             };
         }
 
@@ -100,15 +100,47 @@ namespace MakeFunctionJson
 
         /// <summary>
         /// A method is disabled is any of it's parameters have [Disabled] attribute
-        /// or if the method itself or class have the [Disabled] attribute. 
+        /// or if the method itself or class have the [Disabled] attribute. The overloads
+        /// are stringified so that the ScriptHost will do its job.
         /// </summary>
         /// <param name="method"></param>
-        /// <returns></returns>
-        public static bool IsDisabled(this MethodInfo method)
+        /// <returns>a boolean true or false if the outcome is fixed, a string if the ScriptHost should interpret it</returns>
+        public static object GetDisabled(this MethodInfo method)
         {
-            return method.GetParameters().Any(p => p.HasDisabledAsstibute()) ||
-                method.HasDisabledAttribute() ||
-                method.DeclaringType.GetTypeInfo().HasDisabledAttribute();
+            var attribute = method.GetParameters().Select(p => p.GetDisabledAttribute()).Where(a => a != null).FirstOrDefault() ??
+                method.GetDisabledAttribute() ??
+                method.DeclaringType.GetTypeInfo().GetDisabledAttribute();
+            if (attribute != null)
+            {
+                // With a SettingName defined, just put that as string. The ScriptHost will evaluate it.
+                var settingName = attribute.GetValue<string>("SettingName");
+                if (!string.IsNullOrEmpty(settingName))
+                {
+                    return settingName;
+                }
+
+                // Although Microsoft.Azure.WebJobs.Script.ScriptHost.IsDisabled(..) implementation suggests this is not supported (yet), we'll write the full
+                // type name in which the IsDisabled method would be searched if it were implemented. Assuming this is how it would be implemented.
+                // This assumption is based on the discussion in https://github.com/Azure/azure-webjobs-sdk/issues/578
+                var providerType = attribute.GetValue<Type>("ProviderType");
+                if (providerType != null)
+                {
+                    // Test if this type actually has an IsDisabled method matching the signature.
+                    var isDisabledMethod = providerType.GetMethod("IsDisabled", new[] { typeof(MethodInfo) });
+                    if (isDisabledMethod == null || isDisabledMethod.ReturnType != typeof(bool))
+                    {
+                        // The developer defined a type that has no IsDisabled method.
+                        throw new MissingMethodException($"The IsDisabled method does not exist in given type {providerType.FullName} or does not have the correct signature");
+                    }
+                    return providerType.FullName;
+                }
+
+                // With neither settingName or providerType, no arguments were given and it should always be true
+                return true;
+            }
+
+            // No attribute means not disabled
+            return false;
         }
 
         /// <summary>
@@ -116,9 +148,9 @@ namespace MakeFunctionJson
         /// </summary>
         /// <param name="method"></param>
         /// <returns></returns>
-        public static bool HasDisabledAttribute(this MethodInfo method)
+        public static Attribute GetDisabledAttribute(this MethodInfo method)
         {
-            return method.GetCustomAttributes().Any(a => a.GetType().FullName == "Microsoft.Azure.WebJobs.DisableAttribute");
+            return method.GetCustomAttributes().FirstOrDefault(a => a.GetType().FullName == "Microsoft.Azure.WebJobs.DisableAttribute");
         }
     }
 }

--- a/src/Microsoft.NET.Sdk.Functions/MakeFunction/ParameterInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions/MakeFunction/ParameterInfoExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
+using System;
 
 namespace MakeFunctionJson
 {
@@ -46,9 +47,9 @@ namespace MakeFunctionJson
         /// </summary>
         /// <param name="parameterInfo"></param>
         /// <returns></returns>
-        public static bool HasDisabledAsstibute(this ParameterInfo parameterInfo)
+        public static Attribute GetDisabledAttribute(this ParameterInfo parameterInfo)
         {
-            return parameterInfo.GetCustomAttributes().Any(a => a.GetType().FullName == "Microsoft.Azure.WebJobs.DisableAttribute");
+            return parameterInfo.GetCustomAttributes().FirstOrDefault(a => a.GetType().FullName == "Microsoft.Azure.WebJobs.DisableAttribute");
         }
     }
 }

--- a/src/Microsoft.NET.Sdk.Functions/MakeFunction/TypeInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions/MakeFunction/TypeInfoExtensions.cs
@@ -11,9 +11,9 @@ namespace MakeFunctionJson
             return typeInfo.ImplementedInterfaces.Any(i => i.Name.Equals(interfaceName, StringComparison.OrdinalIgnoreCase));
         }
 
-        public static bool HasDisabledAttribute(this TypeInfo type)
+        public static Attribute GetDisabledAttribute(this TypeInfo type)
         {
-            return type.GetCustomAttributes().Any(a => a.GetType().FullName == "Microsoft.Azure.WebJobs.DisableAttribute");
+            return type.GetCustomAttributes().FirstOrDefault(a => a.GetType().FullName == "Microsoft.Azure.WebJobs.DisableAttribute");
         }
     }
 }

--- a/test/Microsoft.NET.Sdk.Functions.Test/DisableAttributeTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.Test/DisableAttributeTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using MakeFunctionJson;
 using Microsoft.Azure.WebJobs;
 using Xunit;
+using System.Reflection;
 
 namespace Microsoft.NET.Sdk.Functions.Test
 {
@@ -16,6 +17,14 @@ namespace Microsoft.NET.Sdk.Functions.Test
 
             [Disable]
             public static void Run3([QueueTrigger("")] string message) { }
+
+            [Disable("function-disabled-setting")]
+            public static void Run4([QueueTrigger("")] string message) { }
+
+            [Disable(typeof(FunctionsClass1))]
+            public static void Run5([QueueTrigger("")] string message) { }
+
+            public static bool IsDisabled(MethodInfo method) { return false; }
         }
 
         [Disable]
@@ -29,17 +38,33 @@ namespace Microsoft.NET.Sdk.Functions.Test
             public static void Run([QueueTrigger("")] string message) { }
         }
 
+        public class FunctionsClass4
+        {
+            [Disable(typeof(FunctionsClass4))]
+            public static void Run([QueueTrigger("")] string message) { }
+        }
+
         [Theory]
         [InlineData(typeof(FunctionsClass1), "Run1", true)]
         [InlineData(typeof(FunctionsClass1), "Run2", false)]
         [InlineData(typeof(FunctionsClass1), "Run3", true)]
+        [InlineData(typeof(FunctionsClass1), "Run4", "function-disabled-setting")]
+        [InlineData(typeof(FunctionsClass1), "Run5", "Microsoft.NET.Sdk.Functions.Test.DisableAttributeTests+FunctionsClass1")]
         [InlineData(typeof(FunctionsClass2), "Run", true)]
         [InlineData(typeof(FunctionsClass3), "Run", false)]
-        public void MethodsWithDisabledParametersShouldBeDisabled(Type type, string methodName, bool expectedIsDisabled)
+        public void MethodsWithDisabledParametersShouldBeDisabled(Type type, string methodName, object expectedIsDisabled)
         {
             var method = type.GetMethod(methodName);
             var funcJson = method.ToFunctionJson(string.Empty);
             funcJson.Disabled.Should().Be(expectedIsDisabled);
+        }
+
+        [Theory]
+        [InlineData(typeof(FunctionsClass4), "Run")]
+        public void MethodsWithBadProviderShouldThrowException(Type type, string methodName)
+        {
+            var method = type.GetMethod(methodName);
+            Assert.Throws<MissingMethodException>(() => method.ToFunctionJson(string.Empty));
         }
     }
 }

--- a/test/Microsoft.NET.Sdk.Functions.Test/DisableAttributeTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.Test/DisableAttributeTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Sdk.Functions.Test
             public static void Run([QueueTrigger("")] string message) { }
         }
 
-        public class FunctionClass3
+        public class FunctionsClass3
         {
             public static void Run([QueueTrigger("")] string message) { }
         }

--- a/test/Microsoft.NET.Sdk.Functions.Test/Microsoft.NET.Sdk.Functions.Test.csproj
+++ b/test/Microsoft.NET.Sdk.Functions.Test/Microsoft.NET.Sdk.Functions.Test.csproj
@@ -75,23 +75,23 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.1-alpha1-10677\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.0.1-alpha1-10436\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.1-alpha1-10436\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.0.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Http, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Http.1.0.0-alpha1-10432\lib\net45\Microsoft.Azure.WebJobs.Extensions.Http.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Http.1.0.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Extensions.Http.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.1-alpha1-10677\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.0.1-alpha1-10677\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/test/Microsoft.NET.Sdk.Functions.Test/app.config
+++ b/test/Microsoft.NET.Sdk.Functions.Test/app.config
@@ -22,6 +22,14 @@
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.serviceModel>

--- a/test/Microsoft.NET.Sdk.Functions.Test/packages.config
+++ b/test/Microsoft.NET.Sdk.Functions.Test/packages.config
@@ -13,12 +13,12 @@
   <package id="Microsoft.Azure.DocumentDB" version="1.11.4" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10677" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10677" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.0.1-alpha1-10436" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.1-alpha1-10436" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.0.0-alpha1-10432" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.0.1-alpha1-10677" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.0.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta1" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />


### PR DESCRIPTION
Provided solution for the issue described in #69.

The Test project did not compile out of the box, so I had to update some NuGet references there.

Please note my assumption in `MethodInfoExtensions.cs` at line 122. `ScriptHost.IsDisabled(..)` does not actually seem to support the ProviderType (yet?). Based on a discussion in Azure/azure-webjobs-sdk#578 I've assumed the full type name would be in the text field, such as when the settingName does not exist, it would try to see if it could load the Type.