### PR TITLE
Remove nuget.config inside ProjectTemplates folder

### DIFF
--- a/ProjectTemplate/nuget.config
+++ b/ProjectTemplate/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="FunctionsSdkPath" value="..\src\Microsoft.NET.Sdk.Functions\bin\Release" />
-    <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v2" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
https://github.com/Azure/azure-functions-vs-build-sdk/issues/37
@ahmelsayed @soninaren @bzhu94 

This nuget.config is only used by samples. This shouldn't be needed in the project templates.
