### PR TITLE
Fixing the slashes

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Build.targets
+++ b/src/Microsoft.NET.Sdk.Functions/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Build.targets
@@ -23,10 +23,10 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     
     <!-- TODO: CopyFilesToOutputDirectory does not look at the outdir to copy the pdbs. hence copying it manually. -->
     <!-- Copy the application pdb to the bin folder-->
-    <Move SourceFiles="$(TargetDir)\$(TargetName).pdb"
-      DestinationFiles="$(TargetDir)\bin\$(TargetName).pdb"
+    <Move SourceFiles="$(TargetDir)$(TargetName).pdb"
+      DestinationFiles="$(TargetDir)bin\$(TargetName).pdb"
       OverwriteReadOnlyFiles="true" 
-      Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
+      Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
     
     <BuildFunctions
       TargetPath="$(TargetPath)"
@@ -135,7 +135,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   
     <!-- Target path needs to point to the correct dll so that P2P references work. -->
     <PropertyGroup>
-        <TargetPath>$(TargetDir)\bin\$(TargetFileName)</TargetPath>
+        <TargetPath>$(TargetDir)bin\$(TargetFileName)</TargetPath>
     </PropertyGroup>
   
   </Target>
@@ -163,7 +163,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     AfterTargets="Clean">
 
     <ItemGroup>
-      <_FilesInTargetDir Include="$(TargetDir)\**\*" />
+      <_FilesInTargetDir Include="$(TargetDir)**\*" />
     </ItemGroup>
 
     <Delete Files="@(_FilesInTargetDir)"

--- a/src/Microsoft.NET.Sdk.Functions/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.targets
+++ b/src/Microsoft.NET.Sdk.Functions/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.targets
@@ -48,7 +48,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     
     <PropertyGroup>
       <PublishDir>$(FunctionsDir)</PublishDir>
-      <FunctionsTargetPath>$(PublishDir)\bin\$(TargetFileName)</FunctionsTargetPath>
+      <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
+      <FunctionsTargetPath>$(PublishDir)bin\$(TargetFileName)</FunctionsTargetPath>
       <FunctionsOutputPath>$(FunctionsDir)</FunctionsOutputPath>
     </PropertyGroup>
     
@@ -66,7 +67,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <PropertyGroup>
       <PublishDir>$(PublishIntermediateOutputPath)</PublishDir>
-      <FunctionsTargetPath>$(PublishDir)\bin\$(TargetFileName)</FunctionsTargetPath>
+      <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
+      <FunctionsTargetPath>$(PublishDir)bin\$(TargetFileName)</FunctionsTargetPath>
       <FunctionsOutputPath>$(PublishIntermediateOutputPath)</FunctionsOutputPath>
     </PropertyGroup>
 
@@ -128,13 +130,13 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Target Name="_GenerateFunctionsAndCopyContentFiles">
 
     <ItemGroup>
-      <FunctionsPublishAssemblies Include="$(PublishDir)\*.dll;
-                                           $(PublishDir)\*.pdb" />
+      <FunctionsPublishAssemblies Include="$(PublishDir)*.dll;
+                                           $(PublishDir)*.pdb" />
     </ItemGroup>
     
     <!-- Copy the additional assemblies to the bin folder-->
     <Move SourceFiles="@(FunctionsPublishAssemblies)"
-      DestinationFiles="$(PublishDir)\bin\%(Filename)%(Extension)"
+      DestinationFiles="$(PublishDir)bin\%(Filename)%(Extension)"
       OverwriteReadOnlyFiles="true" />
     
     <BuildFunctions


### PR DESCRIPTION
@ahmelsayed @watashiSHUN 

When there are duplicate slashes in the path, msbuild move task is throwing an exception in Kudu but still copies the files.  This PR is to remove the duplicate slashes from the path.