### PR TITLE
Use platform aware directory separators

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.Generator/PathUtility.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/PathUtility.cs
@@ -8,10 +8,7 @@ namespace MakeFunctionJson
     {
         internal static string MakeRelativePath(string fromPath, string toPath)
         {
-            if (!fromPath.EndsWith(@"\"))
-            {
-                fromPath += @"\";
-            }
+            fromPath = fromPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
 
             Uri fromUri = new Uri(fromPath);
             Uri toUri = new Uri(toPath);


### PR DESCRIPTION
This change fixes the issue posted here: 
https://github.com/Azure/azure-functions-vs-build-sdk/issues/142

Basically using windows specific directory separator caused PathUtility to generate an incorrect relative path to the assembly from the function.json. This incorrect value is set in function.json which does not work.