### PR TITLE
Fix empty warning on build

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
@@ -61,8 +61,11 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
                 var output = process.StandardOutput.ReadToEnd();
                 var error = process.StandardError.ReadToEnd();
                 process.WaitForExit();
-
-                Log.LogWarning(output);
+                
+                if (!string.IsNullOrEmpty(output)) 
+                { 
+                    Log.LogWarning(output);
+                }
 
                 if (process.ExitCode != 0 || !string.IsNullOrEmpty(error))
                 {


### PR DESCRIPTION
The output from the generator process is checked and only logged as warning, if the output is not empty.

When a project was built from Visual Studio, the build task logged the process output as warning, even when the output was empty. This resulted in an empty warning in Visual Studio.

Fixes #149 