### PR TITLE
Fix test InvalidFunctionMethodProducesWarning: Remove InlineData for …

### DIFF
--- a/test/Microsoft.NET.Sdk.Functions.Generator.Tests/FunctionJsonConverterTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.Generator.Tests/FunctionJsonConverterTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.NET.Sdk.Functions.Test
         
         [Theory]
         [InlineData(typeof(InvalidFunctionBecauseOfMissingTrigger), "Method Microsoft.NET.Sdk.Functions.Test.FunctionJsonConverterTests+InvalidFunctionBecauseOfMissingTrigger.Run is missing a trigger attribute. Both a trigger attribute and FunctionName attribute are required for an Azure function definition.")]
-        [InlineData(typeof(InvalidFunctionBecauseOfMissingFunctionName), "Method Microsoft.NET.Sdk.Functions.Test.FunctionJsonConverterTests+InvalidFunctionBecauseOfMissingFunctionName.Run is missing the 'FunctionName' attribute. Both a trigger attribute and 'FunctionName' are required for an Azure function definition.")]
+        // [InlineData(typeof(InvalidFunctionBecauseOfMissingFunctionName), "Method Microsoft.NET.Sdk.Functions.Test.FunctionJsonConverterTests+InvalidFunctionBecauseOfMissingFunctionName.Run is missing the 'FunctionName' attribute. Both a trigger attribute and 'FunctionName' are required for an Azure function definition.")]
         [InlineData(typeof(InvalidFunctionBecauseOfBothNoAutomaticTriggerAndServiceBusTrigger), "Method Microsoft.NET.Sdk.Functions.Test.FunctionJsonConverterTests+InvalidFunctionBecauseOfBothNoAutomaticTriggerAndServiceBusTrigger.Run has both a 'NoAutomaticTrigger' attribute and a trigger attribute. Both can't be used together for an Azure function definition.")]
         public void InvalidFunctionMethodProducesWarning(Type type, string warningMessage)
         {


### PR DESCRIPTION
…testing if FunctionNameAttribute, but trigger attribute is present.

Because the check if a FunctionNameAttribute is present is now done before the other checks (to avoid errors - see #151) this test case (trigger attribute is present, but FunctionNameAttribute is not) does not produce a warning anymore.

The presence of warning (if it has been produced during generation) is checked in the test and because of this the test fails.

The InlineData attribute is just commented out (and not removed), because if the underlying problem (#151 as workaround) is fixed, the test case can be enabled again.