### PR TITLE
Empty methods

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
@@ -114,8 +114,8 @@ namespace MakeFunctionJson
                     obj.Remove("authLevel");
                 }
 
-                // Remove methods if there's nothing otherwise
-                // it generates as [] and 404s all requests to the function.
+                // Remove methods if there's nothing.
+                // Otherwise it generates as [] and 404s all requests to the function.
                 if (!obj["methods"]?.HasValues ?? false)
                 {
                     obj.Remove("methods");

--- a/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
@@ -106,14 +106,16 @@ namespace MakeFunctionJson
                 }
             }
 
-            // Clear AuthLevel from httpTrigger that has a webHook property
             if (obj["type"]?.ToString() == "httpTrigger")
             {
+                // Clear AuthLevel if there's a webHookType.
                 if (obj["webHookType"]?.ToString() != null)
                 {
                     obj.Remove("authLevel");
                 }
 
+                // Remove methods if there's nothing otherwise
+                // it generates as [] and 404s all requests to the function.
                 if (!obj["methods"]?.HasValues ?? false)
                 {
                     obj.Remove("methods");

--- a/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
@@ -107,9 +107,17 @@ namespace MakeFunctionJson
             }
 
             // Clear AuthLevel from httpTrigger that has a webHook property
-            if (obj["type"]?.ToString() == "httpTrigger" && obj["webHookType"]?.ToString() != null)
+            if (obj["type"]?.ToString() == "httpTrigger")
             {
-                obj.Remove("authLevel");
+                if (obj["webHookType"]?.ToString() != null)
+                {
+                    obj.Remove("authLevel");
+                }
+
+                if (!obj["methods"]?.HasValues ?? false)
+                {
+                    obj.Remove("methods");
+                }
             }
 
             return obj;

--- a/test/Microsoft.NET.Sdk.Functions.Generator.Tests/HttpTriggerTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.Generator.Tests/HttpTriggerTests.cs
@@ -71,5 +71,15 @@ namespace Microsoft.NET.Sdk.Functions.Test
 
             jObject["methods"].Should().BeNull();
         }
+
+        [Fact]
+        public void HttpTriggerAttributeWithMethodsArrayShouldHaveMethods()
+        {
+            var attribute = new HttpTriggerAttribute("get");
+
+            var jObject = attribute.ToJObject();
+
+            jObject["methods"].Should().NotBeNull();
+        }
     }
 }

--- a/test/Microsoft.NET.Sdk.Functions.Generator.Tests/HttpTriggerTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.Generator.Tests/HttpTriggerTests.cs
@@ -35,5 +35,41 @@ namespace Microsoft.NET.Sdk.Functions.Test
 
             jObject["authLevel"].Should().BeNull();
         }
+
+        [Fact]
+        public void HttpTriggerAttributeWithWebHookTypeAndAuthLevelShouldntHaveMethods()
+        {
+            var attribute = new HttpTriggerAttribute(AuthorizationLevel.Anonymous)
+            {
+                WebHookType = "something"
+            };
+
+            var jObject = attribute.ToJObject();
+
+            jObject["methods"].Should().BeNull();
+        }
+
+        [Fact]
+        public void HttpTriggerAttributeWithWebHookTypeAndNoAuthLevelShouldntHaveMethods()
+        {
+            var attribute = new HttpTriggerAttribute()
+            {
+                WebHookType = "something"
+            };
+
+            var jObject = attribute.ToJObject();
+
+            jObject["methods"].Should().BeNull();
+        }
+
+        [Fact]
+        public void HttpTriggerAttributeWithEmptyMethodsArrayShouldntHaveMethods()
+        {
+            var attribute = new HttpTriggerAttribute(new string[] { });
+
+            var jObject = attribute.ToJObject();
+
+            jObject["methods"].Should().BeNull();
+        }
     }
 }


### PR DESCRIPTION
When the `HttpTriggerAttribute` uses a constructor with the `AuthorizationLevel` and no methods, it generates an empty array for the function.json file. This causes the method to 404 because no methods are allowed.

This change removes an empty methods array as is isn't a valid form of configuration (IMO).