### PR TITLE
Doesn't create a window when generating functions

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
             return new ProcessStartInfo
             {
                 UseShellExecute = false,
-                CreateNoWindow = false,
+                CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
                 WorkingDirectory = workingDirectory,


### PR DESCRIPTION
When running unit tests continuously (such as with NCrunch), I'm constantly interrupted by a console window appearing to execute the Generator. If it's not necessary for you to display the console window (since all output is routed back to MSBuild anyway), this would improve my life a lot.

Here's the [related NCrunch thread](http://forum.ncrunch.net/yaf_postsm11752_Azure-Functions-project-causes-a-Console-to-be-open-every-time-NCrunch-builds.aspx) on their forum.