### PR TITLE
Add updates for host.json and local.settings.json to the build props

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.props
@@ -24,5 +24,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
  -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Functions.Publish.props" Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Functions.Publish.props')" />
 
+  <ItemGroup>
+    <None Update="host.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
+    <None Update="local.settings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This adds globs to cover host.json and local.settings.json to the build props. A couple people have run in to situations where the entries covering these files have been removed from the csproj file & therefore end up with a "No job functions found" message coming from the CLI (https://developercommunity.visualstudio.com/content/problem/149690/no-job-functions-found-message-with-unchanged-azur.html)

With this change, these entries could be removed from the default project file.

cc @vijayrkn 