### PR TITLE
Fixing ZIP Deploy for profiles that have DeployIisAppPath instead of PublishUrl

### DIFF
--- a/pack/Microsoft.NET.Sdk.Functions/Microsoft.NET.Sdk.Functions.csproj
+++ b/pack/Microsoft.NET.Sdk.Functions/Microsoft.NET.Sdk.Functions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <PackageName>Microsoft.NET.Sdk.Functions</PackageName>
-    <Version>1.0.14</Version>
+    <Version>1.0.15</Version>
     <Authors>Microsoft</Authors>
     <ProjectUrl>https://github.com/Azure/azure-functions-vs-build-sdk</ProjectUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-vs-build-sdk</PackageProjectUrl>

--- a/sample/FunctionAppNETFramework/FunctionAppNETFramework/FunctionAppNETFramework.csproj
+++ b/sample/FunctionAppNETFramework/FunctionAppNETFramework/FunctionAppNETFramework.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.14" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FunctionsRefClassicClassLib\FunctionsRefClassicClassLib.csproj" />

--- a/sample/FunctionAppNETFxNETStandard/FunctionAppNETFramework/FunctionAppNETFramework.csproj
+++ b/sample/FunctionAppNETFxNETStandard/FunctionAppNETFramework/FunctionAppNETFramework.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.14" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FunctionsRefNETStandard\FunctionsRefNETStandard.csproj" />

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/AssemblyInfo.cs
@@ -5,5 +5,6 @@
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
 #else
 [assembly: InternalsVisibleTo("Microsoft.NET.Sdk.Functions.Test")]
+[assembly: InternalsVisibleTo("Microsoft.NET.Sdk.Functions.MSBuild.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 #endif

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/Resources.Designer.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/Resources.Designer.cs
@@ -62,6 +62,15 @@ namespace Microsoft.NET.Sdk.Functions.MSBuild.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Neither SiteName nor PublishUrl was given a value..
+        /// </summary>
+        internal static string NeitherSiteNameNorPublishUrlGivenError {
+            get {
+                return ResourceManager.GetString("NeitherSiteNameNorPublishUrlGivenError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Publishing {0} to {1}....
         /// </summary>
         internal static string PublishingZipViaZipDeploy {

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/Resources.resx
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="NeitherSiteNameNorPublishUrlGivenError" xml:space="preserve">
+    <value>Neither SiteName nor PublishUrl was given a value.</value>
+  </data>
   <data name="PublishingZipViaZipDeploy" xml:space="preserve">
     <value>Publishing {0} to {1}...</value>
   </data>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.ZipDeploy.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.ZipDeploy.targets
@@ -42,8 +42,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <ZipDeployTask 
       ZipToPublishPath="$(ZippedPublishContentsPath)" 
       DeploymentUsername="$(UserName)" 
-      DeploymentPassword="$(Password)" 
-      SiteName="$(DeployIisAppPath)" />
+      DeploymentPassword="$(Password)"
+      ScmSiteUrl="$(ScmSiteUrl)" />
   </Target>
 
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.ZipDeploy.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.ZipDeploy.targets
@@ -43,6 +43,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       ZipToPublishPath="$(ZippedPublishContentsPath)" 
       DeploymentUsername="$(UserName)" 
       DeploymentPassword="$(Password)"
+      SiteName="$(DeployIisAppPath)"
       PublishUrl="$(PublishUrl)" />
   </Target>
 

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.ZipDeploy.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.ZipDeploy.targets
@@ -43,7 +43,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       ZipToPublishPath="$(ZippedPublishContentsPath)" 
       DeploymentUsername="$(UserName)" 
       DeploymentPassword="$(Password)"
-      ScmSiteUrl="$(ScmSiteUrl)" />
+      PublishUrl="$(PublishUrl)" />
   </Target>
 
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/ZipDeployTask.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/ZipDeployTask.cs
@@ -21,31 +21,31 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
         public string DeploymentPassword { get; set; }
 
         [Required]
-        public string ScmSiteUrl { get; set; }
+        public string PublishUrl { get; set; }
 
         public override bool Execute()
         { 
             using(DefaultHttpClient client = new DefaultHttpClient())
             {
-                System.Threading.Tasks.Task<bool> t = ZipDeployAsync(ZipToPublishPath, DeploymentUsername, DeploymentPassword, ScmSiteUrl, client);
+                System.Threading.Tasks.Task<bool> t = ZipDeployAsync(ZipToPublishPath, DeploymentUsername, DeploymentPassword, PublishUrl, client);
                 t.Wait();
                 return t.Result;
             }
         }
 
-        private async System.Threading.Tasks.Task<bool> ZipDeployAsync(string zipToPublishPath, string userName, string password, string scmSiteUrl, IHttpClient client)
+        private async System.Threading.Tasks.Task<bool> ZipDeployAsync(string zipToPublishPath, string userName, string password, string publishUrl, IHttpClient client)
         {
             if (!File.Exists(ZipToPublishPath) || client == null)
             {
                 return false;
             }
 
-            if (!scmSiteUrl.EndsWith("/"))
+            if (!publishUrl.EndsWith("/"))
             {
-                scmSiteUrl += "/";
+                publishUrl += "/";
             }
 
-            string zipDeployPublishUrl = scmSiteUrl  + "api/zipdeploy";
+            string zipDeployPublishUrl = publishUrl  + "api/zipdeploy";
 
             Log.LogMessage(MessageImportance.High, String.Format(Resources.PublishingZipViaZipDeploy, zipToPublishPath, zipDeployPublishUrl));
 

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/ZipDeployTask.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/ZipDeployTask.cs
@@ -40,7 +40,12 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
                 return false;
             }
 
-            string zipDeployPublishUrl = scmSiteUrl  + "/api/zipdeploy";
+            if (!scmSiteUrl.EndsWith("/"))
+            {
+                scmSiteUrl += "/";
+            }
+
+            string zipDeployPublishUrl = scmSiteUrl  + "api/zipdeploy";
 
             Log.LogMessage(MessageImportance.High, String.Format(Resources.PublishingZipViaZipDeploy, zipToPublishPath, zipDeployPublishUrl));
 

--- a/test/Microsoft.NET.Sdk.Functions.MSBuild.Tests/Microsoft.NET.Sdk.Functions.MSBuild.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Functions.MSBuild.Tests/Microsoft.NET.Sdk.Functions.MSBuild.Tests.csproj
@@ -14,4 +14,10 @@
     <ProjectReference Include="..\..\src\Microsoft.NET.Sdk.Functions.MSBuild\Microsoft.NET.Sdk.Functions.MSBuild.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Resources\TestPublishContents.zip">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.NET.Sdk.Functions.MSBuild.Tests/ZipDeployerTaskTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.MSBuild.Tests/ZipDeployerTaskTests.cs
@@ -39,7 +39,7 @@ namespace ZipDeployPublish.Test
             Mock<IHttpClient> client = new Mock<IHttpClient>();
             ZipDeployTask zipDeployer = new ZipDeployTask();
 
-            bool result = await zipDeployer.ZipDeployAsync(string.Empty, "username", "password", "siteName", client.Object);
+            bool result = await zipDeployer.ZipDeployAsync(string.Empty, "username", "password", "publishUrl", null, client.Object);
 
             client.Verify(c => c.PostAsync(It.IsAny<Uri>(), It.IsAny<StreamContent>()), Times.Never);
             Assert.False(result);
@@ -77,7 +77,7 @@ namespace ZipDeployPublish.Test
 
             ZipDeployTask zipDeployer = new ZipDeployTask();
 
-            bool result = await zipDeployer.ZipDeployAsync(TestZippedPublishContentsPath, "username", "password", "siteName", client.Object);
+            bool result = await zipDeployer.ZipDeployAsync(TestZippedPublishContentsPath, "username", "password", "https://sitename.scm.azurewebsites.net", null, client.Object);
 
             client.Verify(c => c.PostAsync(
                 It.Is<Uri>(uri => string.Equals(uri.AbsoluteUri, "https://sitename.scm.azurewebsites.net/api/zipdeploy", StringComparison.Ordinal)), 

--- a/test/Microsoft.NET.Sdk.Functions.MSBuild.Tests/ZipDeployerTaskTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.MSBuild.Tests/ZipDeployerTaskTests.cs
@@ -39,10 +39,52 @@ namespace ZipDeployPublish.Test
             Mock<IHttpClient> client = new Mock<IHttpClient>();
             ZipDeployTask zipDeployer = new ZipDeployTask();
 
-            bool result = await zipDeployer.ZipDeployAsync(string.Empty, "username", "password", "publishUrl", null, client.Object);
+            bool result = await zipDeployer.ZipDeployAsync(string.Empty, "username", "password", "publishUrl", null, client.Object, false);
 
             client.Verify(c => c.PostAsync(It.IsAny<Uri>(), It.IsAny<StreamContent>()), Times.Never);
             Assert.False(result);
+        }
+
+        /// <summary>
+        /// ZipDeploy should use PublishUrl if not null or empty, else use SiteName.
+        /// </summary>
+        [Theory]
+        [InlineData("https://sitename.scm.azurewebsites.net", null, "https://sitename.scm.azurewebsites.net/api/zipdeploy")]
+        [InlineData("https://sitename.scm.azurewebsites.net", "", "https://sitename.scm.azurewebsites.net/api/zipdeploy")]
+        [InlineData("https://sitename.scm.azurewebsites.net", "shouldNotBeUsed", "https://sitename.scm.azurewebsites.net/api/zipdeploy")]
+        [InlineData(null, "sitename", "https://sitename.scm.azurewebsites.net/api/zipdeploy")]
+        [InlineData("", "sitename", "https://sitename.scm.azurewebsites.net/api/zipdeploy")]
+        public async Task ExecuteZipDeploy_PublishUrlOrSiteNameGiven(string publishUrl, string siteName, string expectedZipDeployEndpoint)
+        {
+            Action<Mock<IHttpClient>, bool> verifyStep = (client, result) =>
+            {
+                client.Verify(c => c.PostAsync(
+                It.Is<Uri>(uri => string.Equals(uri.AbsoluteUri, expectedZipDeployEndpoint, StringComparison.Ordinal)),
+                It.Is<StreamContent>(streamContent => IsStreamContentEqualToFileContent(streamContent, TestZippedPublishContentsPath))),
+                Times.Once);
+                Assert.True(result);
+            };
+
+            await RunZipDeployAsyncTest(publishUrl, siteName, HttpStatusCode.OK, verifyStep);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        public async Task ExecuteZipDeploy_NeitherPublishUrlNorSiteNameGiven(string publishUrl, string siteName)
+        {
+            Action<Mock<IHttpClient>, bool> verifyStep = (client, result) =>
+            {
+                client.Verify(c => c.PostAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<StreamContent>()),
+                Times.Never);
+                Assert.False(result);
+            };
+
+            await RunZipDeployAsyncTest(publishUrl, siteName, HttpStatusCode.OK, verifyStep);
         }
 
         [Theory]
@@ -53,6 +95,20 @@ namespace ZipDeployPublish.Test
         [InlineData(HttpStatusCode.RequestTimeout, false)]
         [InlineData(HttpStatusCode.InternalServerError, false)]
         public async Task ExecuteZipDeploy_VaryingHttpResponseStatuses(HttpStatusCode responseStatusCode, bool expectedResult)
+        {
+            Action<Mock<IHttpClient>, bool> verifyStep = (client, result) =>
+            {
+                client.Verify(c => c.PostAsync(
+                It.Is<Uri>(uri => string.Equals(uri.AbsoluteUri, "https://sitename.scm.azurewebsites.net/api/zipdeploy", StringComparison.Ordinal)),
+                It.Is<StreamContent>(streamContent => IsStreamContentEqualToFileContent(streamContent, TestZippedPublishContentsPath))),
+                Times.Once);
+                Assert.Equal(expectedResult, result);
+            };
+
+            await RunZipDeployAsyncTest("https://sitename.scm.azurewebsites.net", null, responseStatusCode, verifyStep);
+        }
+
+        private async Task RunZipDeployAsyncTest(string publishUrl, string siteName, HttpStatusCode responseStatusCode, Action<Mock<IHttpClient>, bool> verifyStep)
         {
             Mock<IHttpClient> client = new Mock<IHttpClient>();
 
@@ -77,13 +133,9 @@ namespace ZipDeployPublish.Test
 
             ZipDeployTask zipDeployer = new ZipDeployTask();
 
-            bool result = await zipDeployer.ZipDeployAsync(TestZippedPublishContentsPath, "username", "password", "https://sitename.scm.azurewebsites.net", null, client.Object);
+            bool result = await zipDeployer.ZipDeployAsync(TestZippedPublishContentsPath, "username", "password", publishUrl, siteName, client.Object, false);
 
-            client.Verify(c => c.PostAsync(
-                It.Is<Uri>(uri => string.Equals(uri.AbsoluteUri, "https://sitename.scm.azurewebsites.net/api/zipdeploy", StringComparison.Ordinal)), 
-                It.Is<StreamContent>(streamContent => IsStreamContentEqualToFileContent(streamContent, TestZippedPublishContentsPath))),
-                Times.Once);
-            Assert.Equal(expectedResult, result);
+            verifyStep(client, result);
         }
 
         private bool IsStreamContentEqualToFileContent(StreamContent streamContent, string filePath)


### PR DESCRIPTION
This fixes publish for profiles that were created prior to 15.8 Preview 4