### PR TITLE
Update "Microsoft.NET.Sdk.Functions.Generator" to netcoreapp2.1

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.Generator/Microsoft.NET.Sdk.Functions.Generator.csproj
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/Microsoft.NET.Sdk.Functions.Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
   </PropertyGroup>
@@ -14,7 +14,7 @@
     <DefineConstants>$(DefineConstants);RELESE_BUILD</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Newtonsoft.Json" Version="[11.0.2]" />
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />


### PR DESCRIPTION
.NET Core 2.0 will reach End of Life on October 1, 2018 and support Azure Functions of netcoreapp2.1.
Ref #229 