### PR TITLE
Updating package version ranges to be inclusive

### DIFF
--- a/pack/Microsoft.NET.Sdk.Functions/Microsoft.NET.Sdk.Functions.csproj
+++ b/pack/Microsoft.NET.Sdk.Functions/Microsoft.NET.Sdk.Functions.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <PackageName>Microsoft.NET.Sdk.Functions</PackageName>
-    <Version>1.0.23</Version>
+    <Version>1.0.24</Version>
     <Authors>Microsoft</Authors>
     <ProjectUrl>https://github.com/Azure/azure-functions-vs-build-sdk</ProjectUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-vs-build-sdk</PackageProjectUrl>
@@ -104,9 +104,9 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="Newtonsoft.Json" Version="[9.0.1]" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="[2.2.0,2.3.0)" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="[2.2.0,2.3.0)" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="[1.1.0,1.2.0)" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="[2.2.0,2.4.0)" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="[2.2.0,2.4.0)" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="[1.1.0,1.3.0)" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Preparing to release 2.3.0 packages, but the current 1.0.23 version of the tools isn't inclusive of this version, causing package installation to fail.