### PR TITLE
allowing for a direct reference to ExtensionsMetadataGenerator

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />    
+    <add key="azure_app_service_staging" value="https://www.myget.org/F/azure-appservice-staging/api/v2" />
+  </packageSources>
+</configuration>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/ExtensionsMetadataGeneratorVersion.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/ExtensionsMetadataGeneratorVersion.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <ExtensionsMetadataGeneratorVersion>1.1.0</ExtensionsMetadataGeneratorVersion>
+    <ExtensionsMetadataGeneratorVersion>1.1.1</ExtensionsMetadataGeneratorVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.props
@@ -10,6 +10,10 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <_NuGetPackageRoot>$([MSBuild]::EnsureTrailingSlash('$(NuGetPackageRoot)'))</_NuGetPackageRoot>
+  </PropertyGroup>
+  
   <!--
   ***********************************************************************************************
   Import the Version Props
@@ -38,9 +42,16 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   <!--
   ***********************************************************************************************
-  Import the ExtensionsMetadataGenerator Props
+  Import the ExtensionsMetadataGenerator Props, but only if it has not already been imported.  
   ***********************************************************************************************
  -->
-  <Import Project="$(MSBuildThisFileDirectory)ExtensionsMetadataGeneratorVersion.props" Condition="Exists('$(MSBuildThisFileDirectory)ExtensionsMetadataGeneratorVersion.props')" />
-  <Import Project="$(NuGetPackageRoot)microsoft.azure.webjobs.script.extensionsmetadatagenerator\$(ExtensionsMetadataGeneratorVersion)\build\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.props" Condition="Exists('$(NuGetPackageRoot)microsoft.azure.webjobs.script.extensionsmetadatagenerator\$(ExtensionsMetadataGeneratorVersion)\build\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.props')" />
+  <Import Project="$(MSBuildThisFileDirectory)ExtensionsMetadataGeneratorVersion.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)ExtensionsMetadataGeneratorVersion.props')" />
+
+  <PropertyGroup>
+    <_ExtensionsMetadataGeneratorPropsPath>$(_NuGetPackageRoot)microsoft.azure.webjobs.script.extensionsmetadatagenerator\$(ExtensionsMetadataGeneratorVersion)\build\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.props</_ExtensionsMetadataGeneratorPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ExtensionsMetadataGeneratorPropsPath)"
+          Condition="'$(_ExtensionsMetadataGeneratorPropsImported)' == '' And Exists('$(_ExtensionsMetadataGeneratorPropsPath)')" />
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.targets
@@ -8,7 +8,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 ***********************************************************************************************
 -->
-<Project ToolsVersion="14.0"
+<Project ToolsVersion="14.0" InitialTargets="_InitializeFunctionsSdk"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
@@ -53,11 +53,26 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   <!--
   ***********************************************************************************************
-  Import the ExtensionsMetadataGenerator targets.
+  Import the ExtensionsMetadataGenerator targets, but only if it has not already been imported.
   This must be imported after the Functions Build and Publish targets.
   ***********************************************************************************************
  -->
-  <Import Project="$(NuGetPackageRoot)microsoft.azure.webjobs.script.extensionsmetadatagenerator\$(ExtensionsMetadataGeneratorVersion)\build\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets"
-          Condition="Exists('$(NuGetPackageRoot)microsoft.azure.webjobs.script.extensionsmetadatagenerator\$(ExtensionsMetadataGeneratorVersion)\build\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets')" />
+  <PropertyGroup>
+    <_ExtensionsMetadataGeneratorTargetsPath>$(_NuGetPackageRoot)microsoft.azure.webjobs.script.extensionsmetadatagenerator\$(ExtensionsMetadataGeneratorVersion)\build\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets</_ExtensionsMetadataGeneratorTargetsPath>
+  </PropertyGroup>
+  
+  <Import Project="$(_ExtensionsMetadataGeneratorTargetsPath)"
+          Condition="'$(_ExtensionsMetadataGeneratorTargetsImported)' == '' And Exists('$(_ExtensionsMetadataGeneratorTargetsPath)')" />
+
+  <!--
+  ***********************************************************************************************
+  Ensure that ExtensionsMetadataGenerator is imported. The ExtensionsMetadataGenerator package
+  runs its initialization after this target, so do not change the name.
+  ***********************************************************************************************
+ -->
+  <Target Name="_InitializeFunctionsSdk">
+    <Error Text="The ExtensionsMetadataGenerator package was not imported correctly. Are you missing '$(_ExtensionsMetadataGeneratorTargetsPath)' or '$(_ExtensionsMetadataGeneratorPropsPath)'?"
+           Condition="'$(_ExtensionsMetadataGeneratorTargetsImported)' == '' Or '$(_ExtensionsMetadataGeneratorPropsImported)' == ''" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-host/issues/4383.
Part of the fix for https://github.com/Azure/azure-functions-vs-build-sdk/issues/277.

In conjunction with https://github.com/Azure/azure-functions-host/pull/4398.

Several pieces here:
- If `NUGET_PACKAGES` is missing a trailing slash, the property `NugetPackageRoot` will also be missing that slash.  We didn't take that into account so our paths weren't resolving to anything in this case. It was tough to diagnose because some things *do* work -- like the auto-generated `nuget.g.props/.targets' files. These take this into consideration and create the correct string depending on what this property has. Ensuring the trailing slash will fix one class of issues.
- If someone were to directly reference `ExtensionsMetadataGenerator` -- for example, because they want to move that forward and we don't have a corresponding Sdk release yet -- the MSBuild/Nuget behavior would add that targets file *before* the Sdk's targets file. This means that some properties we depend on won't be there. It also could result in a duplicate targets/props import, which is a warning. To take care of these scenarios:
  - We conditionally check whether the props/targets files have been loaded.
  - If for some reason we can't find the correct file, we'll write an error. This should be rare now, but it would have helped diagnose this issue so I wanted to add it.