### PR TITLE
removing check for ExtensionsMetadataGenerator in v1 projects

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/ExtensionsMetadataGeneratorVersion.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/ExtensionsMetadataGeneratorVersion.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <ExtensionsMetadataGeneratorVersion>1.1.1</ExtensionsMetadataGeneratorVersion>
+    <ExtensionsMetadataGeneratorVersion>1.1.2</ExtensionsMetadataGeneratorVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.targets
@@ -71,8 +71,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   ***********************************************************************************************
  -->
   <Target Name="_InitializeFunctionsSdk">
-    <Error Text="The ExtensionsMetadataGenerator package was not imported correctly. Are you missing '$(_ExtensionsMetadataGeneratorTargetsPath)' or '$(_ExtensionsMetadataGeneratorPropsPath)'?"
-           Condition="'$(_ExtensionsMetadataGeneratorTargetsImported)' == '' Or '$(_ExtensionsMetadataGeneratorPropsImported)' == ''" />
+    <Warning Text="The ExtensionsMetadataGenerator package was not imported correctly. Are you missing '$(_ExtensionsMetadataGeneratorTargetsPath)' or '$(_ExtensionsMetadataGeneratorPropsPath)'?"
+             Condition="($(AzureFunctionsVersion) == 'v2' OR $(AzureFunctionsVersion) == 'v2-prerelease') And ('$(_ExtensionsMetadataGeneratorTargetsImported)' == '' Or '$(_ExtensionsMetadataGeneratorPropsImported)' == '')" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-host/issues/4545.

My check for ExtensionsMetadataGenerator was too aggressive and failed in v1 apps if you didn't already happen to have the ExtensionsMetadataGenerator installed in your nuget cache. So:
- Only check on v2 apps (it'll still be useful for debugging build failures).
- Change it to a warning so it doesn't completely blow up.