### PR TITLE
Generator scans assembly's dependencies for functions. Resolves #274.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,16 +1,16 @@
-REM Restor the solution
+REM Restore the solution.
 dotnet restore
 if errorlevel 1 GOTO ERROR
 
-REM build the functions sdk.
+REM Build the functions sdk.
 dotnet build src\Microsoft.NET.Sdk.Functions.MSBuild --configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM build the functions generator
+REM Build the functions generator.
 dotnet build src\Microsoft.NET.Sdk.Functions.Generator --configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM Pack the functions sdk
+REM Pack the functions sdk.
 dotnet pack pack\Microsoft.NET.Sdk.Functions --configuration=Release
 if errorlevel 1 GOTO ERROR
 
@@ -18,7 +18,7 @@ REM Remove the functions sdk in the user profile so that the built sdk will be r
 rmdir /S /Q %userprofile%\.nuget\packages\microsoft.net.sdk.functions
 if errorlevel 1 GOTO ERROR
 
-REM Restore the NuGet.exe
+REM Restore the NuGet.exe.
 dotnet restore sample\NuGet\NuGet.csproj
 if errorlevel 1 GOTO ERROR
 
@@ -33,15 +33,15 @@ REM Build the sample NETFramework solution.
 msbuild sample\FunctionAppNETFramework\FunctionAppNETFramework.sln /p:configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM Publish the sample .NETFramework functon app using the publish target (full framework msbuild).
+REM Publish the sample .NETFramework function app using the publish target (full framework msbuild).
 msbuild sample\FunctionAppNETFramework\FunctionAppNETFramework\FunctionAppNETFramework.csproj /t:Publish /p:PublishDir="bin\Release\dotnetpublishoutput" /p:configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM Publish the sample .NETFramework functon app using DeployOnBuild (full framework msbuild).
+REM Publish the sample .NETFramework function app using DeployOnBuild (full framework msbuild).
 msbuild sample\FunctionAppNETFramework\FunctionAppNETFramework\FunctionAppNETFramework.csproj /p:DeployOnBuild=true /p:PublishUrl="bin\Release\deployOnBuildOutput" /p:configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM Run tests on .NETFramework projects
+REM Run tests on .NETFramework projects.
 
 dotnet test sample\FunctionAppNETFramework\UnitTestProject2\UnitTestProject2.csproj --configuration=Release --no-build
 if errorlevel 1 GOTO ERROR
@@ -49,7 +49,7 @@ if errorlevel 1 GOTO ERROR
 dotnet test sample\FunctionAppNETFramework\XUnitTestProject1\XUnitTestProject1.csproj --configuration=Release --no-build
 if errorlevel 1 GOTO ERROR
 
-REM run tests on unit test projects that references the functions project.
+REM Run tests on unit test projects that references the functions project.
 dotnet test sample\FunctionAppNETFramework\UnitTestProject1\UnitTestProject1.csproj --configuration=Release --no-build
 if errorlevel 1 GOTO ERROR
 
@@ -65,19 +65,19 @@ REM Build the sample NETStandard solution.
 msbuild sample\FunctionAppNETStandard\FunctionAppNETStandard.sln /p:configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM Publish the sample .NETStandard functon app using the publish target (core msbuild).
+REM Publish the sample .NETStandard function app using the publish target (core msbuild).
 dotnet build sample\FunctionAppNETStandard\FunctionAppNETStandard\FunctionAppNETStandard.csproj /t:Publish /p:PublishDir="bin\Release\core\dotnetpublishoutput" /p:configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM Publish the sample .NETStandard functon app using DeployOnBuild (core msbuild).
+REM Publish the sample .NETStandard function app using DeployOnBuild (core msbuild).
 dotnet build sample\FunctionAppNETStandard\FunctionAppNETStandard\FunctionAppNETStandard.csproj /p:DeployOnBuild=true /p:PublishUrl="bin\Release\core\deployOnBuildOutput" /p:configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM Publish the sample .NETStandard functon app using the publish target (full framework msbuild).
+REM Publish the sample .NETStandard function app using the publish target (full framework msbuild).
 msbuild sample\FunctionAppNETStandard\FunctionAppNETStandard\FunctionAppNETStandard.csproj /t:Publish /p:PublishDir="bin\Release\full\dotnetpublishoutput" /p:configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM Publish the sample .NETStandard functon app using DeployOnBuild (full framework msbuild).
+REM Publish the sample .NETStandard function app using DeployOnBuild (full framework msbuild).
 msbuild sample\FunctionAppNETStandard\FunctionAppNETStandard\FunctionAppNETStandard.csproj /p:DeployOnBuild=true /p:PublishUrl="bin\Release\full\deployOnBuildOutput" /p:configuration=Release
 if errorlevel 1 GOTO ERROR
 

--- a/devbuild.cmd
+++ b/devbuild.cmd
@@ -1,16 +1,16 @@
-REM Restor the solution
+REM Restore the solution.
 dotnet restore
 if errorlevel 1 GOTO ERROR
 
-REM build the functions sdk.
+REM Build the functions sdk.
 dotnet build src\Microsoft.NET.Sdk.Functions.MSBuild --configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM build the functions generator
+REM Build the functions generator.
 dotnet build src\Microsoft.NET.Sdk.Functions.Generator --configuration=Release
 if errorlevel 1 GOTO ERROR
 
-REM Pack the functions sdk
+REM Pack the functions sdk.
 dotnet pack pack\Microsoft.NET.Sdk.Functions --configuration=Release
 if errorlevel 1 GOTO ERROR
 

--- a/sample/FunctionAppNETFramework/FunctionAppNETFramework/FunctionAppNETFramework.csproj
+++ b/sample/FunctionAppNETFramework/FunctionAppNETFramework/FunctionAppNETFramework.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+    <FunctionsInDependencies>true</FunctionsInDependencies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.15" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FunctionsRefClassicClassLib\FunctionsRefClassicClassLib.csproj" />

--- a/sample/FunctionAppNETFramework/FunctionAppNETFramework/RefUser.cs
+++ b/sample/FunctionAppNETFramework/FunctionAppNETFramework/RefUser.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using FunctionsRefSdkClassLib;
+
+namespace FunctionAppNETFramework
+{
+    // Uses references so compiler won't strip them out of the managed module.
+    class RefUser
+    {
+        public Type FunctionsRefSdkClassLibStandard { get => typeof(HttpTriggerRefSdkNETFramework); }
+    }
+}

--- a/sample/FunctionAppNETFramework/FunctionsRefSdkClassLib/Class1.cs
+++ b/sample/FunctionAppNETFramework/FunctionsRefSdkClassLib/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace FunctionsRefSdkClassLib
-{
-    public class Class1
-    {
-    }
-}

--- a/sample/FunctionAppNETFramework/FunctionsRefSdkClassLib/FunctionsRefSdkClassLib.csproj
+++ b/sample/FunctionAppNETFramework/FunctionsRefSdkClassLib/FunctionsRefSdkClassLib.csproj
@@ -1,7 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+  </ItemGroup>
 
 </Project>

--- a/sample/FunctionAppNETFramework/FunctionsRefSdkClassLib/HttpTriggerRefSdkNETFramework.cs
+++ b/sample/FunctionAppNETFramework/FunctionsRefSdkClassLib/HttpTriggerRefSdkNETFramework.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Host;
+
+namespace FunctionsRefSdkClassLib
+{
+    public class HttpTriggerRefSdkNETFramework
+    {
+        [FunctionName("HttpTriggerRefSdkNETFramework")]
+        public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequestMessage req, TraceWriter log)
+        {
+            //log.Info("C# HTTP trigger function processed a request.");
+
+            // parse query parameter
+            string name = req.GetQueryNameValuePairs()
+                .FirstOrDefault(q => string.Compare(q.Key, "name", true) == 0)
+                .Value;
+
+            return name == null
+                ? req.CreateResponse(HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")
+                : req.CreateResponse(HttpStatusCode.OK, "Hello " + name);
+        }
+    }
+}

--- a/sample/FunctionAppNETFramework/UnitTestProject1/UnitTest1.cs
+++ b/sample/FunctionAppNETFramework/UnitTestProject1/UnitTest1.cs
@@ -27,6 +27,22 @@ namespace UnitTestProject1
         }
 
         [TestMethod]
+        public async Task ClassicUnitTestProject_Test_NETFx_Ref()
+        {
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, "https://functions.azurewebsites.net?name=test")
+            {
+                Content = new StringContent(""),
+                Properties = { { HttpPropertyKeys.HttpConfigurationKey, new HttpConfiguration() } }
+            };
+
+            var response = await HttpTriggerNETFramework.Run(requestMessage, null);
+
+            string responseString = await response.Content.ReadAsStringAsync();
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            Assert.AreEqual("\"Hello test\"", responseString);
+        }
+
+        [TestMethod]
         public void ClassicUnitTestProject_Empty()
         {
             Assert.IsTrue(true);

--- a/sample/FunctionAppNETFramework/UnitTestProject2/UnitTest1.cs
+++ b/sample/FunctionAppNETFramework/UnitTestProject2/UnitTest1.cs
@@ -27,6 +27,22 @@ namespace UnitTestProject2
         }
 
         [TestMethod]
+        public async Task NewProjectSystem_MsTest_NETFx_Ref()
+        {
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, "https://functions.azurewebsites.net?name=test")
+            {
+                Content = new StringContent(""),
+                Properties = { { HttpPropertyKeys.HttpConfigurationKey, new HttpConfiguration() } }
+            };
+
+            var response = await HttpTriggerNETFramework.Run(requestMessage, null);
+
+            string responseString = await response.Content.ReadAsStringAsync();
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            Assert.AreEqual("\"Hello test\"", responseString);
+        }
+
+        [TestMethod]
         public void NewProjectSystem_MsTest_Empty()
         {
             Assert.IsTrue(true);

--- a/sample/FunctionAppNETFramework/XUnitTestProject1/UnitTest1.cs
+++ b/sample/FunctionAppNETFramework/XUnitTestProject1/UnitTest1.cs
@@ -26,6 +26,21 @@ namespace XUnitTestProject1
             Assert.Equal("\"Hello test\"", responseString);
         }
 
+        [Fact]
+        public async Task XUnitTest_NETFx_Ref()
+        {
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, "https://functions.azurewebsites.net?name=test")
+            {
+                Content = new StringContent(""),
+                Properties = { { HttpPropertyKeys.HttpConfigurationKey, new HttpConfiguration() } }
+            };
+
+            var response = await HttpTriggerNETFramework.Run(requestMessage, null);
+
+            string responseString = await response.Content.ReadAsStringAsync();
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal("\"Hello test\"", responseString);
+        }
 
         [Fact]
         public void NewProjectSystem_XUnit_Empty()

--- a/sample/FunctionAppNETStandard/FunctionAppNETStandard/FunctionAppNETStandard.csproj
+++ b/sample/FunctionAppNETStandard/FunctionAppNETStandard/FunctionAppNETStandard.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <FunctionsInDependencies>true</FunctionsInDependencies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.14" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/sample/FunctionAppNETStandard/FunctionAppNETStandard/RefUser.cs
+++ b/sample/FunctionAppNETStandard/FunctionAppNETStandard/RefUser.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using FunctionsRefNETStandard;
+
+namespace FunctionAppNETStandard
+{
+    // Uses references so compiler won't strip them out of the managed module.
+    class RefUser
+    {
+        public Type FunctionsRefNetStandard { get => typeof(HttpTriggerRefNETStandard); }
+    }
+}

--- a/sample/FunctionAppNETStandard/FunctionsRefNETStandard/Class1.cs
+++ b/sample/FunctionAppNETStandard/FunctionsRefNETStandard/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace FunctionsRefNETStandard
-{
-    public class Class1
-    {
-    }
-}

--- a/sample/FunctionAppNETStandard/FunctionsRefNETStandard/FunctionsRefNETStandard.csproj
+++ b/sample/FunctionAppNETStandard/FunctionsRefNETStandard/FunctionsRefNETStandard.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+  </ItemGroup>
+
 </Project>

--- a/sample/FunctionAppNETStandard/FunctionsRefNETStandard/HttpTriggerRefNETStandard.cs
+++ b/sample/FunctionAppNETStandard/FunctionsRefNETStandard/HttpTriggerRefNETStandard.cs
@@ -1,15 +1,16 @@
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 
-namespace FunctionAppNETStandard
+namespace FunctionsRefNETStandard
 {
-    public static class HttpTriggerNETStandard
+    public class HttpTriggerRefNETStandard
     {
-        [FunctionName("HttpTriggerNETStandard")]
+        [FunctionName("HttpTriggerRefNETStandard")]
         public static IActionResult Run([HttpTrigger]HttpRequest req, ILogger log)
         {
             //log.Info("C# HTTP trigger function processed a request.");

--- a/sample/FunctionAppNETStandard/UnitTestNETFramework/UnitTestNETFramework.cs
+++ b/sample/FunctionAppNETStandard/UnitTestNETFramework/UnitTestNETFramework.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FunctionAppNETStandard;
+using FunctionsRefNETStandard;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,6 +22,18 @@ namespace UnitTestNETFramework
                 Assert.AreEqual("Hello, test", ((OkObjectResult)response).Value);
             }
 
+        }
+
+        [TestMethod]
+        public void NewProjectSystem_MsTest_NETFx_Ref()
+        {
+            HttpRequest httpRequest = new DefaultHttpRequest();
+            var response = HttpTriggerRefNETStandard.Run(httpRequest, null);
+
+            if (response is OkObjectResult)
+            {
+                Assert.AreEqual("Hello, test", ((OkObjectResult)response).Value);
+            }
         }
     }
 }

--- a/sample/FunctionAppNETStandard/UnitTestProject2/UnitTest1.cs
+++ b/sample/FunctionAppNETStandard/UnitTestProject2/UnitTest1.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
 using FunctionAppNETStandard;
+using FunctionsRefNETStandard;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,6 +24,18 @@ namespace UnitTestProject2
                 Assert.AreEqual("Hello, test", ((OkObjectResult)response).Value);
             }
 
+        }
+
+        [TestMethod]
+        public void NewProjectSystem_MsTest_NETFx_Ref()
+        {
+            HttpRequest httpRequest = new DefaultHttpRequest();
+            var response = HttpTriggerRefNETStandard.Run(httpRequest, null);
+
+            if (response is OkObjectResult)
+            {
+                Assert.AreEqual("Hello, test", ((OkObjectResult)response).Value);
+            }
         }
     }
 }

--- a/sample/FunctionAppNETStandard/XUnitTestProject1/UnitTest1.cs
+++ b/sample/FunctionAppNETStandard/XUnitTestProject1/UnitTest1.cs
@@ -1,4 +1,5 @@
 using FunctionAppNETStandard;
+using FunctionsRefNETStandard;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
@@ -19,6 +20,18 @@ namespace XUnitTestProject1
                 Assert.Equal("Hello, test", ((OkObjectResult)response).Value);
             }
 
+        }
+
+        [Fact]
+        public void NewProjectSystem_MsTest_NETFx_Ref()
+        {
+            HttpRequest httpRequest = new UnitTestProject2.DefaultHttpRequest();
+            var response = HttpTriggerRefNETStandard.Run(httpRequest, null);
+
+            if (response is OkObjectResult)
+            {
+                Assert.Equal("Hello, test", ((OkObjectResult)response).Value);
+            }
         }
     }
 }

--- a/src/Microsoft.NET.Sdk.Functions.Generator/Program.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/Program.cs
@@ -10,14 +10,16 @@ namespace Microsoft.NET.Sdk.Functions.Console
         private static void Main(string[] args)
         {
             var logger = new ConsoleLogger();
-            if (args.Length < 2 || args.Length > 3)
+            if (args.Length < 3 || args.Length > 4)
             {
-                logger.LogError("USAGE: <assemblyPath> <outputPath> <excludedFunctionName1;excludedFunctionName2;...>");
+                logger.LogError("USAGE: <assemblyPath> <outputPath> <functionsInDependencies> <excludedFunctionName1;excludedFunctionName2;...>");
             }
             else
             {
                 var assemblyPath = args[0].Trim();
                 var outputPath = args[1].Trim();
+                var functionsInDependencies = bool.Parse(args[2].Trim());
+
                 IEnumerable<string> excludedFunctionNames = Enumerable.Empty<string>();
 
                 if (args.Length > 2)
@@ -26,7 +28,7 @@ namespace Microsoft.NET.Sdk.Functions.Console
                     excludedFunctionNames = excludedFunctionNamesArg.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
                 }
 
-                var converter = new FunctionJsonConverter(logger, assemblyPath, outputPath, excludedFunctionNames);
+                var converter = new FunctionJsonConverter(logger, assemblyPath, outputPath, functionsInDependencies, excludedFunctionNames);
                 if (!converter.TryRun())
                 {
                     logger.LogError("Error generating functions metadata");

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Build.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Build.targets
@@ -43,7 +43,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       OutputPath="$(TargetDir)"
       UseNETCoreGenerator="$(UseNETCoreGenerator)"
       UseNETFrameworkGenerator="$(UseNETFrameworkGenerator)"
-      UserProvidedFunctionJsonFiles="@(UserProvidedFunctionJsonFiles)" />
+      UserProvidedFunctionJsonFiles="@(UserProvidedFunctionJsonFiles)" 
+      FunctionsInDependencies="$(FunctionsInDependencies)"/>
   </Target>
   
     <!--

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.targets
@@ -148,7 +148,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       OutputPath="$(FunctionsOutputPath)"
       UseNETCoreGenerator="$(UseNETCoreGenerator)"
       UseNETFrameworkGenerator="$(UseNETFrameworkGenerator)"
-      UserProvidedFunctionJsonFiles="@(UserProvidedFunctionJsonFiles)" />
+      UserProvidedFunctionJsonFiles="@(UserProvidedFunctionJsonFiles)"
+      FunctionsInDependencies="$(FunctionsInDependencies)" />
   </Target>
   
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
@@ -31,6 +31,8 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
         public bool GenerateHostJson { get; set; }
 
         public ITaskItem[] UserProvidedFunctionJsonFiles { get; set; }
+        
+        public bool FunctionsInDependencies { get; set; }
 
         public override bool Execute()
         {
@@ -89,7 +91,7 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
         {
             string workingDirectory = isCore ? Path.Combine(baseLocation, NETStandardFolder) : Path.Combine(baseLocation, NETFrameworkFolder);
             string exePath = isCore ? DotNetMuxer.MuxerPathOrDefault() : Path.Combine(workingDirectory, "Microsoft.NET.Sdk.Functions.Generator.exe");
-            string arguments = isCore ? $"Microsoft.NET.Sdk.Functions.Generator.dll \"{TargetPath} \" \"{OutputPath} \"" : $"\"{TargetPath} \" \"{OutputPath} \"";
+            string arguments = isCore ? $"Microsoft.NET.Sdk.Functions.Generator.dll \"{TargetPath} \" \"{OutputPath} \" \"{FunctionsInDependencies} \"" : $"\"{TargetPath} \" \"{OutputPath} \" \"{FunctionsInDependencies} \"";
 
             string excludedFunctionNamesArg = UserProvidedFunctionJsonFiles?
                     .Select(f => f.ItemSpec.Replace("/", @"\").Replace(@"\function.json", string.Empty))


### PR DESCRIPTION
* This functionality is off by default; to enable, set the project property
`FunctionsInDependencies` to True.
* Compilers can be too smart, and may strip out unused references. To ensure
that a referenced project's DLL is included in the assembly's dependencies,
make sure the assembly's code explicitly references a member or type from the
referenced project.