### PR TITLE
Fix assembly loading

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.Generator/Program.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/Program.cs
@@ -23,11 +23,6 @@ namespace Microsoft.NET.Sdk.Functions.Console
                 var outputPath = args[1].Trim();
                 var functionsInDependencies = bool.Parse(args[2].Trim());
 
-                AssemblyLoadContext.Default.Resolving += (context, assemblyName) =>
-                {
-                    return context.LoadFromAssemblyPath(Path.Combine(assemblyDir, assemblyName.Name + ".dll"));
-                };
-
                 IEnumerable<string> excludedFunctionNames = Enumerable.Empty<string>();
 
                 if (args.Length > 2)


### PR DESCRIPTION
Fix assembly loading when dealing with different versions of libraries
than what the SDK has a dependency on. This should resolve numerous
issues with types not loading in the generator itself. In addition, some
places where you typically would get a rather unhelpfull
`NullReferenceException`, a check for null values have been added,
throwing `InvalidOperationException`s with more helpfull error messages.

Resolves #359