### PR TITLE
fixing publish for v2 apps with .NET Core 3 SDK installed

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.targets
@@ -167,5 +167,25 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       UserProvidedFunctionJsonFiles="@(UserProvidedFunctionJsonFiles)"
       FunctionsInDependencies="$(FunctionsInDependencies)" />
   </Target>
-  
+
+  <!--
+    ============================================================
+                  _ResolveCopyLocalAssetsForPublishFunctions
+
+    Moves all CopyLocal assemblies to bin folder. This will only run 
+    on builds that are using .NET Core 3 SDK.
+    ============================================================
+    -->
+  <Target
+   Name="_ResolveCopyLocalAssetsForPublishFunctions"
+   AfterTargets="_ResolveCopyLocalAssetsForPublish">
+
+    <ItemGroup>
+      <_ResolvedCopyLocalPublishAssets>
+        <DestinationSubDirectory>bin\%(_ResolvedCopyLocalPublishAssets.DestinationSubDirectory)</DestinationSubDirectory>
+      </_ResolvedCopyLocalPublishAssets>
+    </ItemGroup>
+
+  </Target>
+
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <FunctionsSdkVersion>1.0.30-beta4</FunctionsSdkVersion>
+    <FunctionsSdkVersion>1.0.30</FunctionsSdkVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #333 

This is a port of #354 for the 1.0 release. If .NET Core 3 SDK is installed, the targets used are different and we were missing this step in this case. I tested this with targeting the 2.2 SDK as well and it continued to work (this target won't get hit in that scenario).