### PR TITLE
base deps file copy on AssemblyName, not ProjectName [v3.x]

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
@@ -84,7 +84,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     ============================================================
     -->
   <Target Name="_FunctionsPostBuildDepsCopy" AfterTargets="PostBuildEvent" Condition="'$(SkipFunctionsDepsCopy)' != 'true'">
-    <Copy SourceFiles="$(OutDir)$(ProjectName).deps.json" DestinationFiles="$(OutDir)bin\function.deps.json" Condition="Exists('$(OutDir)$(ProjectName).deps.json')"/>
+    <Copy SourceFiles="$(OutDir)$(AssemblyName).deps.json" DestinationFiles="$(OutDir)bin\function.deps.json" Condition="Exists('$(OutDir)$(AssemblyName).deps.json')"/>
   </Target>
 
   <!--


### PR DESCRIPTION
If your assembly name didn't match your project name, we'd fail to copy the deps.json file. Thanks to @Ponomareff for catching this here: https://github.com/Azure/Azure-Functions/issues/1370#issuecomment-565086901