### PR TITLE
basing deps copy (for publish) on AssemblyName [v3.x]

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.targets
@@ -118,7 +118,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     ============================================================
     -->
   <Target Name="_FunctionsPublishDepsCopy" BeforeTargets="Publish" Condition="'$(SkipFunctionsDepsCopy)' != 'true'">
-    <Copy SourceFiles="$(PublishDir)$(ProjectName).deps.json" DestinationFiles="$(PublishDir)bin\function.deps.json" Condition="Exists('$(PublishDir)$(ProjectName).deps.json')"/>
+    <Copy SourceFiles="$(PublishDir)$(AssemblyName).deps.json" DestinationFiles="$(PublishDir)bin\function.deps.json" Condition="Exists('$(PublishDir)$(AssemblyName).deps.json')"/>
   </Target>
 
 

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <FunctionsSdkVersion>3.0.2</FunctionsSdkVersion>
+    <FunctionsSdkVersion>3.0.3</FunctionsSdkVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
When fixing #363, I missed the change to the publish targets.