### PR TITLE
 adding _IsFunctionsSdkBuild to props file; bumping versions

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/ExtensionsMetadataGeneratorVersion.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/ExtensionsMetadataGeneratorVersion.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <ExtensionsMetadataGeneratorVersion>1.1.5</ExtensionsMetadataGeneratorVersion>
+    <ExtensionsMetadataGeneratorVersion>1.1.7</ExtensionsMetadataGeneratorVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <FunctionsSdkVersion>1.0.34</FunctionsSdkVersion>
+    <FunctionsSdkVersion>1.0.35</FunctionsSdkVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.props
@@ -12,6 +12,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
   <PropertyGroup>
     <_NuGetPackageRoot>$([MSBuild]::EnsureTrailingSlash('$(NuGetPackageRoot)'))</_NuGetPackageRoot>
+    <_IsFunctionsSdkBuild>true</_IsFunctionsSdkBuild>
   </PropertyGroup>
   
   <!--


### PR DESCRIPTION
Moving this setting explicitly to a props file allows us to take advantage of this in ExtensionsMetadataGenerator. Note that 1.1.7 doesn't exist yet -- that'll be published soon.