### PR TITLE
copy all bin/pdb files to /bin during build

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/ExtensionsMetadataGeneratorVersion.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/ExtensionsMetadataGeneratorVersion.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <ExtensionsMetadataGeneratorVersion>1.1.7</ExtensionsMetadataGeneratorVersion>
+    <ExtensionsMetadataGeneratorVersion>1.1.8</ExtensionsMetadataGeneratorVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
@@ -23,13 +23,16 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <PropertyGroup>
       <UseNETCoreGenerator Condition="$(UseNETCoreGenerator)=='' AND !$(AzureFunctionsVersion.StartsWith('v1'))">true</UseNETCoreGenerator>
     </PropertyGroup>
-    <!-- TODO: CopyFilesToOutputDirectory does not look at the outdir to copy the pdbs. hence copying it manually. -->
-    <!-- Copy the application pdb to the bin folder-->
-    <Move SourceFiles="$(TargetDir)$(TargetName).pdb"
-      DestinationFiles="$(TargetDir)bin\$(TargetName).pdb"
-      OverwriteReadOnlyFiles="true" 
-      Condition="Exists('$(TargetDir)$(TargetName).pdb')"
-      ContinueOnError="true"/>
+
+    <ItemGroup>
+      <FunctionsBuildAssemblies Include="$(TargetDir)*.dll;
+                                         $(TargetDir)*.pdb" />
+    </ItemGroup>
+
+    <!-- Copy the additional assemblies to the bin folder-->
+    <Move SourceFiles="@(FunctionsBuildAssemblies)"
+          DestinationFiles="$(TargetDir)bin\%(Filename)%(Extension)"
+          OverwriteReadOnlyFiles="true" />
 
     <ItemGroup>
       <UserProvidedFunctionJsonFiles Include="@(None);@(Content)" Condition="Exists(%(Identity))

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <FunctionsSdkVersion>1.0.35</FunctionsSdkVersion>
+    <FunctionsSdkVersion>1.0.36</FunctionsSdkVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Part 2 of https://github.com/Azure/azure-functions-host/issues/5963.

One of the issues here was the discrepancy between what we do during a build and what we do during a publish. Previously, during a build, we'd only copy the project pdb and assembly to the /bin folder. During publish, we copy all pdb and dlls. So in the case of this bug, the customers all ran into an issue during publish, but not during build (and the build behavior was wrong).

I've copied this publish logic and moved it to build: https://github.com/Azure/azure-functions-vs-build-sdk/blob/master/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.targets#L152-L160