### PR TITLE
Fixing the task assembly load issue

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>$(AssemblyVersion)</FileVersion>
+    <Version>$(AssemblyVersion)</Version>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
@@ -47,7 +47,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       UseNETCoreGenerator="$(UseNETCoreGenerator)"
       UseNETFrameworkGenerator="$(UseNETFrameworkGenerator)"
       UserProvidedFunctionJsonFiles="@(UserProvidedFunctionJsonFiles)" 
-      FunctionsInDependencies="$(FunctionsInDependencies)"/>
+      FunctionsInDependencies="$(FunctionsInDependencies)"
+      TaskAssemblyDirectory="$(_FunctionsTasksDir)"/>
   </Target>
   
     <!--

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.targets
@@ -165,7 +165,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       UseNETCoreGenerator="$(UseNETCoreGenerator)"
       UseNETFrameworkGenerator="$(UseNETFrameworkGenerator)"
       UserProvidedFunctionJsonFiles="@(UserProvidedFunctionJsonFiles)"
-      FunctionsInDependencies="$(FunctionsInDependencies)" />
+      FunctionsInDependencies="$(FunctionsInDependencies)" 
+      TaskAssemblyDirectory="$(_FunctionsTasksDir)"/>
   </Target>
 
   <!--

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <FunctionsSdkVersion>1.0.36</FunctionsSdkVersion>
+    <FunctionsSdkVersion>1.0.37</FunctionsSdkVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -21,8 +20,8 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
         [Required]
         public string OutputPath { get; set; }
 
-        private const string NETFrameworkFolder = "net46";
-        private const string NETStandardFolder = "netcoreapp2.1";
+        [Required]
+        public string TaskAssemblyDirectory { get; set; }
 
         public bool UseNETCoreGenerator { get; set; }
 
@@ -34,6 +33,9 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
 
         public bool FunctionsInDependencies { get; set; }
 
+        private const string NETFrameworkFolder = "net46";
+        private const string NETStandardFolder = "netcoreapp2.1";
+
         public override bool Execute()
         {
             string hostJsonPath = Path.Combine(OutputPath, "host.json");
@@ -43,8 +45,8 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
                 File.WriteAllText(hostJsonPath, hostJsonString);
             }
 
-            string taskAssemblyDirectory = Path.GetDirectoryName(typeof(GenerateFunctions).GetTypeInfo().Assembly.Location);
-            string baseDirectory = Path.GetDirectoryName(taskAssemblyDirectory);
+            string taskDirectoryFullPath = Path.GetFullPath(TaskAssemblyDirectory).TrimEnd(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar });
+            string baseDirectory = Path.GetDirectoryName(taskDirectoryFullPath);
             ProcessStartInfo processStartInfo = null;
 #if NET46
             processStartInfo = GetProcessStartInfo(baseDirectory, isCore: false);


### PR DESCRIPTION
Fix this issue: https://github.com/Azure/azure-functions-vs-build-sdk/issues/199

This should allow the 3 versions of the assemblies to load side by side
![image](https://user-images.githubusercontent.com/3981619/82017756-b9eeee80-9638-11ea-9b4e-d08f5fff7025.png)
