### PR TITLE
Fixing the path to the task dll

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
         public bool FunctionsInDependencies { get; set; }
 
         private const string NETFrameworkFolder = "net46";
-        private const string NETStandardFolder = "netcoreapp2.1";
+        private const string NETStandardFolder = "netcoreapp3.0";
 
         public override bool Execute()
         {


### PR DESCRIPTION
The cherry-pick change from 2.1 caused the path to be changed to netcoreapp2.1 instead of netcoreapp3.0. Fixing. 