### PR TITLE
Fix 'Find All References' and other features in VS caused due to moving files to 'bin' folder

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.props
@@ -9,9 +9,4 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-  
-</Project>
+ </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
@@ -102,53 +102,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     -->
   <Target
    Name="_ResolveAdditionalReferenceCopyLocalPathsForFunctions"
-   DependsOnTargets="_RunResolvePublishAssembliesForFunctions"
    AfterTargets="ResolveReferences"
      >
-
-    <!--
-      Copy publish assemblies that not already included in ReferenceCopyLocalPaths
-      via CopyLocalLockFileAssemblies=true. This will include RID-specific assets 
-      that would be published in  the runtimes/ folder, but excluded from 
-      CopyLocalLockFileAssemblies when no RuntimeIdentifier is set.
-    -->
-    <ItemGroup Condition="'$(RuntimeIdentifier)' == ''">
-      <!-- 
-       NOTE: The exclusion here is to ensure that we do not override any existing 
-             ReferenceCopyLocalPaths with assets from RunResolvedPublishAssemblies.
-             The ReferenceCopyLocalPaths can have conflicts resolved that are not 
-             also resolved in the publish set, and publish currently relies on copy
-             local paths having precedence over it to ensure conflict resolution 
-             applies. We must preserve that precedence here.
-     -->
-      <_RidSpecificAssembliesByDestination
-        Include="@(ResolvedAssembliesToPublish->'%(DestinationSubPath)')"
-        Exclude="@(ReferenceCopyLocalPaths->'%(DestinationSubDirectory)%(Filename)%(Extension)')"
-        OriginalItemSpec="%(ResolvedAssembliesToPublish.Identity)"
-       />
-
-      <_RidSpecificAssembliesByDestination
-        DestinationSubDirectory="%(_RidSpecificAssembliesByDestination.RelativeDir)"
-       />
-
-      <ReferenceCopyLocalPaths
-        Include="@(_RidSpecificAssembliesByDestination->'%(OriginalItemSpec)')"
-        Exclude="@(ReferenceCopyLocalPaths)"
-       />
-      
-    </ItemGroup>
-
-    <!--
-       Copy reference assemblies needed for runtime compilation to refs/ folder. Only 
-       those that are not a also runtime assemblies and therefore already included in 
-       ReferenceCopyLocalPaths via CopyLocalLockFileAssemblies=true are needed.
-      -->
-    <ItemGroup Condition="'$(PreserveCompilationContext)' == 'true'">
-      <ReferenceCopyLocalPaths
-        Include="@(ReferencePath)"
-        Exclude="@(ReferenceCopyLocalPaths)"
-        DestinationSubDirectory="$(RefAssembliesFolderName)\"/>
-    </ItemGroup>
 
     <!-- Force the binaries to be copied to the bin folder.-->
     <ItemGroup>
@@ -167,19 +122,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </PropertyGroup>
   
   </Target>
-
-  <!-- 
-     We only need to call _RunResolvePublishAssembliesForFunctions during build when we do not 
-     have a RuntimeIdentifier.Otherwise, we already have everything we need from
-     CopyLocalLockFileAssemblies.
-   -->
-  <Target
-    Name="_RunResolvePublishAssembliesForFunctions"
-    Condition="'$(RuntimeIdentifier)' == ''"
-    DependsOnTargets="RunResolvePublishAssemblies"
-  />
-  
-  
+ 
     <!--
     ============================================================
                      _FunctionsGetTargetPathWithTargetPlatformMoniker

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Build.targets
@@ -30,7 +30,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </ItemGroup>
 
     <!-- Copy the additional assemblies to the bin folder-->
-    <Move SourceFiles="@(FunctionsBuildAssemblies)"
+    <Copy SourceFiles="@(FunctionsBuildAssemblies)"
           DestinationFiles="$(TargetDir)bin\%(Filename)%(Extension)"
           OverwriteReadOnlyFiles="true" />
 
@@ -42,7 +42,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     </ItemGroup>
 
     <GenerateFunctions
-      TargetPath="$(TargetPath)"
+      TargetPath="$(TargetDir)bin\$(TargetFileName)"
       OutputPath="$(TargetDir)"
       UseNETCoreGenerator="$(UseNETCoreGenerator)"
       UseNETFrameworkGenerator="$(UseNETFrameworkGenerator)"
@@ -51,35 +51,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       TaskAssemblyDirectory="$(_FunctionsTasksDir)"/>
   </Target>
   
-    <!--
-    ============================================================
-                  _FunctionsBeforeCopyFilesToOutputDirectory
-
-    Sets the correct runtime folder for functions
-    ============================================================
-    -->
-  <Target Name="_FunctionsBeforeCopyFilesToOutputDirectory"
-          BeforeTargets="CopyFilesToOutputDirectory">
-      <PropertyGroup>
-        <BackUpOutDirPropertyValue>$(OutDir)</BackUpOutDirPropertyValue>
-        <OutDir>$(OutDir)bin\</OutDir>
-      </PropertyGroup>
-  </Target>
-  
-      <!--
-    ============================================================
-                  _FunctionsAfterCopyFilesToOutputDirectory
-
-    Resets the correct runtime folder for functions
-    ============================================================
-    -->
-  <Target Name="_FunctionsAfterCopyFilesToOutputDirectory"
-          AfterTargets="CopyFilesToOutputDirectory">
-      <PropertyGroup>
-        <OutDir>$(BackUpOutDirPropertyValue)</OutDir>
-      </PropertyGroup>
-  </Target>
-
  <!--
     ============================================================
         _FunctionsPostBuildDepsCopy
@@ -90,64 +61,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Target Name="_FunctionsPostBuildDepsCopy" AfterTargets="PostBuildEvent" Condition="'$(SkipFunctionsDepsCopy)' != 'true'">
     <Copy SourceFiles="$(OutDir)$(AssemblyName).deps.json" DestinationFiles="$(OutDir)bin\function.deps.json" Condition="Exists('$(OutDir)$(AssemblyName).deps.json')"/>
   </Target>
-
-  <!--
-    ============================================================
-        _ResolveAdditionalReferenceCopyLocalPathsForFunctions
-
-    CopyLocalLockFileAssemblies does not copy all the required assemblies 
-    to the TargetDir folder. This target will copy all the required files
-    to the TargetDir folder.
-    ============================================================
-    -->
-  <Target
-   Name="_ResolveAdditionalReferenceCopyLocalPathsForFunctions"
-   AfterTargets="ResolveReferences"
-     >
-
-    <!-- Force the binaries to be copied to the bin folder.-->
-    <ItemGroup>
-      <ReferenceCopyLocalPaths>
-        <DestinationSubDirectory>bin\%(ReferenceCopyLocalPaths.DestinationSubDirectory)</DestinationSubDirectory>
-      </ReferenceCopyLocalPaths>
-
-      <ResolvedAssembliesToPublish>
-        <DestinationSubPath>bin\%(ResolvedAssembliesToPublish.DestinationSubPath)</DestinationSubPath>
-      </ResolvedAssembliesToPublish>
-    </ItemGroup>
-  
-    <!-- Target path needs to point to the correct dll so that P2P references work. -->
-    <PropertyGroup>
-        <TargetPath>$(TargetDir)bin\$(TargetFileName)</TargetPath>
-    </PropertyGroup>
-  
-  </Target>
  
-    <!--
-    ============================================================
-                     _FunctionsGetTargetPathWithTargetPlatformMoniker
-
-     When building a referenced class library from the IDE, it just gathers the build outputs.
-    since IDE has already built the project.
-
-    In this case a seperate msbuild call to GetTargetPath is done from ResolveProjectReferences
-    in Microsoft.Common.CurrentVersion.targets. 
-    
-    Updating the TargetPath before this call will make sure that the right path will be returned.
-    
-    This fixed the p2p reference issues from non-Rosyln project system based class library.
-    ============================================================
-    -->
-  
-    <Target Name="_FunctionsGetTargetPathWithTargetPlatformMoniker" 
-            BeforeTargets="GetTargetPathWithTargetPlatformMoniker" >
-      
-      <PropertyGroup>
-          <TargetPath>$(TargetDir)bin\$(TargetFileName)</TargetPath>
-      </PropertyGroup>
-    
-  </Target>
-  
 
   <!--
     ============================================================


### PR DESCRIPTION
Functions runtime/core-tools expect the binaries to be present in the bin folder but VS on normal builds creates them in the root folder. The previous implementation was to move these files to the bin folder on generation. 

Issue: 
Since the binary folder is different compared to the other .NET Core projects, some of the features in VS does not work properly. e.g: Find all references, references to types needs re-builds, incremental build does not work etc. 

Fix: 
Remove the logic to move the files. Instead after the files are generated to bin, copy the required binaries to the bin folder for the functions core-tools to function. Since we are not moving the assemblies, all VS functionalities should work as expected. 

Publish Impact: None. Publish should just work. The duplicate content will not have any impact on publish since the publish targets are handled differently. 

Fixes: https://github.com/Azure/azure-functions-vs-build-sdk/issues/344