### PR TITLE
Add direction property for trigger

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.Generator/ParameterInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/ParameterInfoExtensions.cs
@@ -35,6 +35,8 @@ namespace MakeFunctionJson
                 {
                     // Add a name property on the JObject that refers to the parameter name.
                     obj["name"] = parameterInfo.Name;
+                    // Add direction property - always "in" for a trigger
+                    obj["direction"] = "in";
                     return obj;
                 })
                 .ToList();

--- a/test/Microsoft.NET.Sdk.Functions.Generator.Tests/FunctionJsonConverterTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.Generator.Tests/FunctionJsonConverterTests.cs
@@ -64,6 +64,7 @@ namespace Microsoft.NET.Sdk.Functions.Test
             var binding = schema.Bindings.Single();
             binding.Value<string>("type").Should().Be(type);
             binding.Value<string>("name").Should().Be(parameterName);
+            binding.Value<string>("direction").Should().Be("in");
             logger.Errors.Should().BeEmpty();
             logger.Warnings.Should().BeEmpty();
         }


### PR DESCRIPTION
Adding "direction": "in" for bindings from precompiled .NET. Note: currently the only trigger binding is added to function.json in this case.