### PR TITLE
Add Durable triggers to TriggersWithoutStorage

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.Generator/FunctionJsonConverter.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/FunctionJsonConverter.cs
@@ -27,7 +27,12 @@ namespace MakeFunctionJson
         private static readonly IEnumerable<string> _triggersWithoutStorage = new[]
         {
             "httptrigger",
-            "kafkatrigger"
+            "kafkatrigger",
+ 
+            // Durable Functions triggers can also support non-Azure Storage backends
+            "orchestrationTrigger",
+            "activityTrigger",
+            "entityTrigger",
         };
 
         internal FunctionJsonConverter(ILogger logger, string assemblyPath, string outputPath, bool functionsInDependencies, IEnumerable<string> excludedFunctionNames = null)


### PR DESCRIPTION
We plan to release public support for non-Azure Storage backends for Durable Functions. In order for the VS build SDK to fully support this, we need to exclude Durable triggers from the list of triggers requiring `AzureWebJobsStorage`.

Note that we already made the same change for the Functions Core Tools: https://github.com/Azure/azure-functions-core-tools/pull/2409