### PR TITLE
Enabling the Disable(Type) attribute overload

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.Generator/FunctionJsonConverter.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/FunctionJsonConverter.cs
@@ -27,7 +27,12 @@ namespace MakeFunctionJson
         private static readonly IEnumerable<string> _triggersWithoutStorage = new[]
         {
             "httptrigger",
-            "kafkatrigger"
+            "kafkatrigger",
+ 
+            // Durable Functions triggers can also support non-Azure Storage backends
+            "orchestrationTrigger",
+            "activityTrigger",
+            "entityTrigger",
         };
 
         internal FunctionJsonConverter(ILogger logger, string assemblyPath, string outputPath, bool functionsInDependencies, IEnumerable<string> excludedFunctionNames = null)

--- a/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
@@ -169,11 +169,6 @@ namespace MakeFunctionJson
                 error = "'%' expressions are not supported for 'Disable'. Use 'Disable(\"settingName\") instead of 'Disable(\"%settingName%\")'";
                 return true;
             }
-            else if (disabled is Type)
-            {
-                error = "the constructor 'DisableAttribute(Type)' is not supported.";
-                return true;
-            }
             else
             {
                 return false;

--- a/test/Microsoft.NET.Sdk.Functions.Generator.Tests/HasUnsupportedAttributesTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.Generator.Tests/HasUnsupportedAttributesTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.NET.Sdk.Functions.Test
         [InlineData(typeof(FunctionsClass1), "Run3", false)]
         [InlineData(typeof(FunctionsClass1), "Run4", false)]
         [InlineData(typeof(FunctionsClass1), "Run5", true)]
-        [InlineData(typeof(FunctionsClass1), "Run6", true)]
+        [InlineData(typeof(FunctionsClass1), "Run6", false)]
         public void HasUnsupportedAttributesWorksCorrectly(Type type, string methodName, bool expected)
         {
             var method = TestUtility.GetMethodDefinition(type, methodName);


### PR DESCRIPTION
This validation was outdated. Tested locally using Microsoft.NET.Sdk.Functions (3.0.2) and Microsoft.Azure.WebJobs (3.0.22).

```csharp
[Disable(typeof(ValidadorDisable))]
[FunctionName(FunctionName)]
public async Task Run([TimerTrigger(CronJob)] TimerInfo timer, ILogger log)
{
    throw new NotImplementedException();
}
```
Retrieving my boolean disabled settings from a config file using the Type overload:

```csharp
public class ValidadorDisable
  {
      public bool IsDisabled(MethodInfo method)
      {
          var functionName = method.GetCustomAttributes(true).OfType<FunctionNameAttribute>().FirstOrDefault().Name;
          return Configuration.Get.FunctionConfiguration.DisabledFunctions[functionName];
      }
  }
```