### PR TITLE
Use more recent vm image on azure devops

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ trigger:
 - main
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2019'
 
 variables:
   devops_buildNumber: $[counter(format(''), 289)]


### PR DESCRIPTION
See https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=45220&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9
(could also be windows-2022 if want to be early)