### PR TITLE
Include all bindings when generating function metadata

### DIFF
--- a/common.props
+++ b/common.props
@@ -3,8 +3,8 @@
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">true</ContinuousIntegrationBuild>
 
     <MajorProductVersion>4</MajorProductVersion>
-    <MinorProductVersion>0</MinorProductVersion>
-    <PatchProductVersion>2</PatchProductVersion>
+    <MinorProductVersion>1</MinorProductVersion>
+    <PatchProductVersion>0</PatchProductVersion>
     
     <!-- Clear this value for non-preview releases -->
     <PreviewProductVersion></PreviewProductVersion>

--- a/common.props
+++ b/common.props
@@ -4,7 +4,7 @@
 
     <MajorProductVersion>4</MajorProductVersion>
     <MinorProductVersion>0</MinorProductVersion>
-    <PatchProductVersion>1</PatchProductVersion>
+    <PatchProductVersion>2</PatchProductVersion>
     
     <!-- Clear this value for non-preview releases -->
     <PreviewProductVersion></PreviewProductVersion>

--- a/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
@@ -69,7 +69,7 @@ namespace MakeFunctionJson
             // Get binding if a return attribute is used.
             // Ex:  [return: Queue("myqueue-items-a", Connection = "MyStorageConnStr")]
             var returnBindings = GetOutputBindingsFromReturnAttribute(method);
-            var allBindings = bindingsFromParameters.Concat(returnBindings);
+            var allBindings = bindingsFromParameters.Concat(returnBindings).ToArray();
 
             return new FunctionJsonSchema
             {
@@ -98,13 +98,8 @@ namespace MakeFunctionJson
             }
 
             var outputBindings = new List<JObject>();
-            foreach (var attribute in method.MethodReturnType.CustomAttributes)
+            foreach (var attribute in method.MethodReturnType.CustomAttributes.Where(a=>a.IsWebJobsAttribute()))
             {
-                if (!attribute.AttributeType.FullName.StartsWith("Microsoft.Azure.WebJobs"))
-                {
-                    continue;
-                }
-
                 var bindingJObject = attribute.ToReflection().ToJObject();
 
                 // return binding must have the direction attribute set to out.

--- a/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
@@ -107,9 +107,11 @@ namespace MakeFunctionJson
                 }
 
                 var bindingJObject = attribute.ToReflection().ToJObject();
-                
+
+                // return binding must have the direction attribute set to out.
+                // https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Utility.cs#L561
                 bindingJObject["name"] = "$return";
-                bindingJObject["Direction"] = "out";
+                bindingJObject["direction"] = "out";
 
                 outputBindings.Add(bindingJObject);
             }

--- a/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
@@ -64,8 +64,7 @@ namespace MakeFunctionJson
             // Every parameter can potentially contain more than 1 attribute that will be converted into a binding object.
             var bindingsFromParameters = method.HasNoAutomaticTriggerAttribute() ? new[] { method.ManualTriggerBinding() } : method.Parameters
                                             .Select(p => p.ToFunctionJsonBindings())
-                                            .SelectMany(i => i)
-                                            .ToArray();
+                                            .SelectMany(i => i);
 
             // Get binding if a return attribute is used.
             // Ex:  [return: Queue("myqueue-items-a", Connection = "MyStorageConnStr")]

--- a/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Mono.Cecil;
@@ -59,15 +60,21 @@ namespace MakeFunctionJson
         /// <returns><see cref="FunctionJsonSchema"/> object that represents the passed in <paramref name="method"/>.</returns>
         public static FunctionJsonSchema ToFunctionJson(this MethodDefinition method, string assemblyPath)
         {
+            // For every SDK parameter, convert it to a FunctionJson bindings.
+            // Every parameter can potentially contain more than 1 attribute that will be converted into a binding object.
+            var bindingsFromParameters = method.HasNoAutomaticTriggerAttribute() ? new[] { method.ManualTriggerBinding() } : method.Parameters
+                                            .Select(p => p.ToFunctionJsonBindings())
+                                            .SelectMany(i => i)
+                                            .ToArray();
+
+            // Get binding if a return attribute is used.
+            // Ex:  [return: Queue("myqueue-items-a", Connection = "MyStorageConnStr")]
+            var returnBindings = GetOutputBindingsFromReturnAttribute(method);
+            var allBindings = bindingsFromParameters.Concat(returnBindings);
+
             return new FunctionJsonSchema
             {
-                // For every SDK parameter, convert it to a FunctionJson bindings.
-                // Every parameter can potentially contain more than 1 attribute that will be converted into a binding object.
-                Bindings = method.HasNoAutomaticTriggerAttribute() ? new[] { method.ManualTriggerBinding() } : method.Parameters
-                    .Where(p => p.IsWebJobSdkTriggerParameter())
-                    .Select(p => p.ToFunctionJsonBindings())
-                    .SelectMany(i => i)
-                    .ToArray(),
+                Bindings = allBindings,
                 // Entry point is the fully qualified name of the function
                 EntryPoint = $"{method.DeclaringType.FullName}.{method.Name}",
                 ScriptFile = assemblyPath,
@@ -75,6 +82,39 @@ namespace MakeFunctionJson
                 // or if the method itself or class have the [Disabled] attribute.
                 Disabled = method.GetDisabled()
             };
+        }
+
+        /// <summary>
+        /// Gets bindings from return expression used with a binding expression.
+        /// Ex:
+        ///     [FunctionName("HttpTriggerWriteToQueue1")]
+        ///     [return: Queue("myqueue-items-a", Connection = "MyStorageConnStra")]
+        ///     public static string Run([HttpTrigger] HttpRequestMessage request) => "foo";
+        /// </summary>
+        private static JObject[] GetOutputBindingsFromReturnAttribute(MethodDefinition method)
+        {
+            if (method.MethodReturnType == null)
+            {
+                return Array.Empty<JObject>();
+            }
+
+            var outputBindings = new List<JObject>();
+            foreach (var attribute in method.MethodReturnType.CustomAttributes)
+            {
+                if (!attribute.AttributeType.FullName.StartsWith("Microsoft.Azure.WebJobs"))
+                {
+                    continue;
+                }
+
+                var bindingJObject = attribute.ToReflection().ToJObject();
+                
+                bindingJObject["name"] = "$return";
+                bindingJObject["Direction"] = "out";
+
+                outputBindings.Add(bindingJObject);
+            }
+
+            return outputBindings.ToArray();
         }
 
         /// <summary>

--- a/test/Microsoft.NET.Sdk.Functions.Generator.Tests/FunctionJsonConverterTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.Generator.Tests/FunctionJsonConverterTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -24,6 +26,24 @@ namespace Microsoft.NET.Sdk.Functions.Test
             [FunctionName("MyHttpTrigger")]
             public static void Run1([HttpTrigger] HttpRequestMessage request) { }
 
+            [FunctionName("HttpTriggerWriteToQueue1")]
+            [return: Queue("myqueue-items-a", Connection = "MyStorageConnStra")]
+            public static string HttpTriggerWriteToQueue1([HttpTrigger] HttpRequestMessage request) => "foo";
+
+            [FunctionName("HttpTriggerWriteToQueue2")]
+            public static void HttpTriggerWriteToQueue2([HttpTrigger] HttpRequestMessage request,
+                [Queue("myqueue-items-b", Connection = "MyStorageConnStrb")] out string msg)
+            {
+                msg = "foo";
+            }
+
+            [FunctionName("HttpTriggerWriteToQueue3")]
+            public static void HttpTriggerWriteToQueue3([HttpTrigger] HttpRequestMessage request,
+            [Queue("myqueue-items-c", Connection = "MyStorageConnStrc")] IAsyncCollector<string> collector)
+            {
+                collector.AddAsync("foo");
+            }
+
             [FunctionName("MyBlobTrigger")]
             public static void Run2([BlobTrigger("blob.txt")] string blobContent) { }
 
@@ -46,24 +66,144 @@ namespace Microsoft.NET.Sdk.Functions.Test
             public static void Run8() { }
         }
 
+        public class BindingAssertionItem
+        {
+            public string FunctionName { set; get; }
+
+            // key is binding type, value is binding parameter name.
+            public Dictionary<string, string> Bindings { set; get; }
+        }
+
+        public class BindingTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyHttpTrigger",
+                        Bindings= new Dictionary<string, string>
+                        {
+                            {"httpTrigger", "request"}
+                        }
+                    }
+                };
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="HttpTriggerWriteToQueue1",
+                        Bindings= new Dictionary<string, string>
+                        {
+                           {"httpTrigger", "request"},
+                           {"queue", "$return"}
+                        }
+                    }
+                };
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="HttpTriggerWriteToQueue2",
+                        Bindings= new Dictionary<string, string>
+                        {
+                           {"httpTrigger", "request"},
+                           {"queue", "msg"}
+                        }
+                    }
+                };
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="HttpTriggerWriteToQueue3",
+                        Bindings= new Dictionary<string, string>
+                        {
+                           {"httpTrigger", "request"},
+                           {"queue", "collector"}
+                        }
+                    }
+                };
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyBlobTrigger",
+                        Bindings= new Dictionary<string, string>
+                        {
+                            {"blobTrigger", "blobContent"}
+                        }
+                    }
+                };
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyEventHubTrigger",
+                        Bindings= new Dictionary<string, string>
+                        {
+                            {"eventHubTrigger", "message"}
+                        }
+                    }
+                };
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyTimerTrigger",
+                        Bindings= new Dictionary<string, string>
+                        {
+                            {"timerTrigger", "timer"}
+                        }
+                    }
+                };
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyServiceBusTrigger",
+                        Bindings= new Dictionary<string, string>
+                        {
+                            {"serviceBusTrigger", "message"}
+                        }
+                    }
+                };
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyManualTrigger",
+                        Bindings= new Dictionary<string, string>
+                        {
+                            {"manualTrigger", "input"}
+                        }
+                    }
+                };
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyManualTriggerWithoutParameters",
+                        Bindings= new Dictionary<string, string>
+                        {
+                            {"manualTrigger", null}
+                        }
+                    }
+                };
+            }
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
         [Theory]
-        [InlineData("MyHttpTrigger", "httpTrigger", "request")]
-        [InlineData("MyBlobTrigger", "blobTrigger", "blobContent")]
-        [InlineData("MyQueueTrigger", "queueTrigger", "queue")]
-        [InlineData("MyEventHubTrigger", "eventHubTrigger", "message")]
-        [InlineData("MyTimerTrigger", "timerTrigger", "timer")]
-        [InlineData("MyServiceBusTrigger", "serviceBusTrigger", "message")]
-        [InlineData("MyManualTrigger", "manualTrigger", "input")]
-        [InlineData("MyManualTriggerWithoutParameters", "manualTrigger", null)]
-        public void FunctionMethodsAreExported(string functionName, string type, string parameterName)
+        [ClassData(typeof(BindingTestData))]
+        public void FunctionMethodsAreExported(BindingAssertionItem item)
         {
             var logger = new RecorderLogger();
             var converter = new FunctionJsonConverter(logger, ".", ".", functionsInDependencies: false);
-            var functions = converter.GenerateFunctions(new[] { TestUtility.GetTypeDefinition(typeof(FunctionsClass)) });
-            var schema = functions.Single(e => Path.GetFileName(e.Value.outputFile.DirectoryName) == functionName).Value.schema;
-            var binding = schema.Bindings.Single();
-            binding.Value<string>("type").Should().Be(type);
-            binding.Value<string>("name").Should().Be(parameterName);
+            var functions = converter.GenerateFunctions(new[] { TestUtility.GetTypeDefinition(typeof(FunctionsClass)) }).ToArray();
+            var schema = functions.Single(e => Path.GetFileName(e.Value.outputFile.DirectoryName) == item.FunctionName).Value.schema;
+
+            schema.Bindings.Count().Should().Be(item.Bindings.Count);
+
+            foreach (var binding in schema.Bindings)
+            {
+                var type=binding.Value<string>("type");
+                var name=binding.Value<string>("name");
+
+                name.Should().Be(item.Bindings[type]);
+            }
+
             logger.Errors.Should().BeEmpty();
             logger.Warnings.Should().BeEmpty();
         }


### PR DESCRIPTION
Currently, when a function invocation happens, we [log binding usage](https://github.com/Azure/azure-functions-host/blob/2b9f7dc08ecb0f525f2e55f44d43eedd25a7c0e2/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs#L82) to our function metrics logs table.  We recently found out that not all the bindings were logged for in-proc precompiled apps.

For in-proc apps, the function.json generated is not including all the bindings. It is including only the trigger bindings. In this PR, we are making a change to include all bindings. 

We have also decided to remove the binding direction from the event name when logging the binding metric in host. 