### PR TITLE
[V3 backport] Include all bindings when generating function metadata (#542)

### DIFF
--- a/test/Microsoft.NET.Sdk.Functions.Generator.Tests/FunctionJsonConverterTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.Generator.Tests/FunctionJsonConverterTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -8,6 +10,7 @@ using MakeFunctionJson;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.WindowsAzure.Storage.Queue;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.NET.Sdk.Functions.Test
@@ -23,6 +26,26 @@ namespace Microsoft.NET.Sdk.Functions.Test
         {
             [FunctionName("MyHttpTrigger")]
             public static void Run1([HttpTrigger] HttpRequestMessage request) { }
+
+            [FunctionName("HttpTriggerQueueReturn")]
+            [return: Queue("myqueue-items-a", Connection = "MyStorageConnStrA")]
+            public static string HttpTriggerQueueReturn([HttpTrigger] HttpRequestMessage request) => "foo";
+
+            [FunctionName("HttpTriggerQueueOutParam")]
+            public static void HttpTriggerQueueOutParam([HttpTrigger] HttpRequestMessage request,
+                [Queue("myqueue-items-b", Connection = "MyStorageConnStrB")] out string msg)
+            {
+                msg = "foo";
+            }
+
+            [FunctionName("HttpTriggerMultipleOutputs")]
+            public static void HttpTriggerMultipleOutputs([HttpTrigger] HttpRequestMessage request,
+                [Blob("binding-metric-test/sample-text.txt", Connection = "MyStorageConnStrC")] out string myBlob,
+                [Queue("myqueue-items-c", Connection = "MyStorageConnStrC")] IAsyncCollector<string> qCollector)
+            {
+                myBlob = "foo-blob";
+                qCollector.AddAsync("foo-queue");
+            }
 
             [FunctionName("MyBlobTrigger")]
             public static void Run2([BlobTrigger("blob.txt")] string blobContent) { }
@@ -46,24 +69,237 @@ namespace Microsoft.NET.Sdk.Functions.Test
             public static void Run8() { }
         }
 
+        public class BindingAssertionItem
+        {
+            public string FunctionName { set; get; }
+            
+            public Dictionary<string, string>[] Bindings { set; get; }
+        }
+
+        public class BindingTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyHttpTrigger",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "httpTrigger" },
+                               {"name" , "request"},
+                               {"authLevel" , "function"}
+                            }
+                        }
+                    }
+                };
+
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="HttpTriggerQueueReturn",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "httpTrigger" },
+                               {"name" , "request"},
+                               {"authLevel" , "function"}
+                            },
+                            new Dictionary<string, string>
+                            {
+                               {"type", "queue" },
+                               {"name" , "$return"},
+                               {"connection" , "MyStorageConnStrA"},
+                               {"queueName","myqueue-items-a" }
+                            }
+                        }
+                    }
+                };
+
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="HttpTriggerQueueOutParam",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "httpTrigger" },
+                               {"name" , "request"},
+                               {"authLevel" , "function"}
+                            },
+                            new Dictionary<string, string>
+                            {
+                               {"type", "queue" },
+                               {"name" , "msg"},
+                               {"connection" , "MyStorageConnStrB"},
+                               {"queueName","myqueue-items-b" }
+                            }
+                        }
+                    }
+                };
+
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="HttpTriggerMultipleOutputs",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "httpTrigger" },
+                               {"name" , "request"},
+                               {"authLevel" , "function"}
+                            },
+                            new Dictionary<string, string>
+                            {
+                               {"type", "queue" },
+                               {"name" , "qCollector"},
+                               {"connection" , "MyStorageConnStrC"},
+                               {"queueName","myqueue-items-c" }
+                            },
+                            new Dictionary<string, string>
+                            {
+                               {"type", "blob" },
+                               {"name" , "myBlob"},
+                               {"blobPath", "binding-metric-test/sample-text.txt" },
+                               {"connection" , "MyStorageConnStrC"}
+                            }
+                        }
+                    }
+                };
+
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyBlobTrigger",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "blobTrigger" },
+                               {"name" , "blobContent"},
+                               {"path" , "blob.txt"}
+                            }
+                        }
+                    }
+                };
+
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyEventHubTrigger",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "eventHubTrigger" },
+                               {"name" , "message"},
+                               {"eventHubName" , "hub"}
+                            }
+                        }
+                    }
+                };
+
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyTimerTrigger",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "timerTrigger" },
+                               {"name" , "timer"},
+                               {"schedule" , "00:30:00"},
+                               {"useMonitor" , "True"},
+                               {"runOnStartup" , "False"}
+                            }
+                        }
+                    }
+                };
+
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyServiceBusTrigger",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "serviceBusTrigger" },
+                               {"name" , "message"},
+                               {"queueName" , "queue"},
+                               {"isSessionsEnabled" , "False"}
+                            }
+                        }
+                    }
+                };
+
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyManualTrigger",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "manualTrigger" },
+                               {"name" , "input"}
+                            }
+                        }
+                    }
+                };
+
+                yield return new object[] {
+                    new BindingAssertionItem
+                    {
+                        FunctionName="MyManualTriggerWithoutParameters",
+                        Bindings = new Dictionary<string, string>[]
+                        {
+                            new Dictionary<string, string>
+                            {
+                               {"type", "manualTrigger" }
+                            }
+                        }
+                    }
+                };                
+            }
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
         [Theory]
-        [InlineData("MyHttpTrigger", "httpTrigger", "request")]
-        [InlineData("MyBlobTrigger", "blobTrigger", "blobContent")]
-        [InlineData("MyQueueTrigger", "queueTrigger", "queue")]
-        [InlineData("MyEventHubTrigger", "eventHubTrigger", "message")]
-        [InlineData("MyTimerTrigger", "timerTrigger", "timer")]
-        [InlineData("MyServiceBusTrigger", "serviceBusTrigger", "message")]
-        [InlineData("MyManualTrigger", "manualTrigger", "input")]
-        [InlineData("MyManualTriggerWithoutParameters", "manualTrigger", null)]
-        public void FunctionMethodsAreExported(string functionName, string type, string parameterName)
+        [ClassData(typeof(BindingTestData))]
+        public void FunctionMethodsAreExported(BindingAssertionItem item)
         {
             var logger = new RecorderLogger();
             var converter = new FunctionJsonConverter(logger, ".", ".", functionsInDependencies: false);
-            var functions = converter.GenerateFunctions(new[] { TestUtility.GetTypeDefinition(typeof(FunctionsClass)) });
-            var schema = functions.Single(e => Path.GetFileName(e.Value.outputFile.DirectoryName) == functionName).Value.schema;
-            var binding = schema.Bindings.Single();
-            binding.Value<string>("type").Should().Be(type);
-            binding.Value<string>("name").Should().Be(parameterName);
+            var functions = converter.GenerateFunctions(new[] { TestUtility.GetTypeDefinition(typeof(FunctionsClass)) }).ToArray();
+            var schemaActual = functions.Single(e => Path.GetFileName(e.Value.outputFile.DirectoryName) == item.FunctionName).Value.schema;
+
+            foreach (var expectedBindingItem in item.Bindings)
+            {
+                var expectedBindingType = expectedBindingItem.FirstOrDefault(a => a.Key == "type");
+
+                // query binding entry from actual using the type.
+                var matchingBindingFromActual = schemaActual.Bindings
+                                                            .First(a => a.Properties().Any(g => g.Name == "type"
+                                                                                             && g.Value.ToString()== expectedBindingType.Value));
+
+                // compare all props of binding entry from expected entry with actual.
+                foreach (var prop in expectedBindingItem)
+                {
+                    // make sure the prop exist in the binding.
+                    matchingBindingFromActual.ContainsKey(prop.Key).Should().BeTrue();
+
+                    // Verify the prop values matches between expected and actual.
+                    expectedBindingItem[prop.Key].Should().Be(matchingBindingFromActual[prop.Key].ToString());
+                }
+            }
+
             logger.Errors.Should().BeEmpty();
             logger.Warnings.Should().BeEmpty();
         }


### PR DESCRIPTION
Cherry picking changes from [PR 542](https://github.com/Azure/azure-functions-vs-build-sdk/pull/542) to v3 branch.

----
Currently, when a function invocation happens, we [log binding usage](https://github.com/Azure/azure-functions-host/blob/2b9f7dc08ecb0f525f2e55f44d43eedd25a7c0e2/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs#L82) to our function metrics logs table.  We recently found out that not all the bindings were logged for in-proc precompiled apps.

For in-proc apps, the function.json generated is not including all the bindings. It is including only the trigger bindings. In this PR, we are making a change to include all bindings. 

We have also decided to remove the binding direction from the event name when logging the binding metric in host. 