### PR TITLE
Install dotnet 2.2 for v3 builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,12 @@ variables:
 
 steps:
 - task: UseDotNet@2
+  displayName: 'Install dotnet v2.x'
+  inputs:
+    packageType: 'sdk'
+    version: '2.2.x'
+    performMultiLevelLookup: true
+- task: UseDotNet@2
   displayName: 'Install dotnet v3.x'
   inputs:
     packageType: 'sdk'


### PR DESCRIPTION
V3 builds are failing because 'Microsoft.NETCore.App', version '2.0.0' was not found. This framework version reached end of life, hence dev ops may have removed it from the agents. Because of this, "BuildAndPublish_V1Functions" is failing. Until we figure out what to do with this test, we have decided to explicitly install 2.2.x version to unblock us from merging some other changes waiting to be merged to 3.x
