### PR TITLE
Bumping up version of v3 package (3.0.13 to 3.1.0)

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Version.props
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <FunctionsSdkVersion>3.0.13</FunctionsSdkVersion>
+    <FunctionsSdkVersion>3.1.0</FunctionsSdkVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Bumping up V3 package version for [Microsoft.NET.Sdk.Functions](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions) . This new version includes the below fix (backported to v3). We have already published the v4 version of this package.

[[V3 backport] Include all bindings when generating function metadata (#542)](https://github.com/Azure/azure-functions-vs-build-sdk/pull/547)