### PR TITLE
Import the Functions design time targets

### DIFF
--- a/common.props
+++ b/common.props
@@ -4,7 +4,7 @@
 
     <MajorProductVersion>4</MajorProductVersion>
     <MinorProductVersion>1</MinorProductVersion>
-    <PatchProductVersion>0</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
     
     <!-- Clear this value for non-preview releases -->
     <PreviewProductVersion></PreviewProductVersion>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
@@ -20,6 +20,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == '' and '$(IsPackable)' == 'false'">true</WarnOnPackingNonPackableProject>
     <IsZipDeploySupported>true</IsZipDeploySupported>
+    <MSBuildFunctionsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed.Functions\</MSBuildFunctionsTargetsPath>
   </PropertyGroup>
 
   <UsingTask TaskName="GenerateFunctions"
@@ -50,6 +51,14 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
  -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Functions.Publish.targets"
           Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Functions.Publish.targets')" />
+
+  <!--
+  ***********************************************************************************************
+  Import the Functions designtime targets if they exist
+  ***********************************************************************************************
+-->
+  <Import Project="$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets" 
+         Condition="Exists('$(MSBuildFunctionsTargetsPath)Microsoft.Azure.Functions.Designtime.targets')" />
 
   <!--
   ***********************************************************************************************


### PR DESCRIPTION
In-proc version of the same change : https://github.com/Azure/azure-functions-dotnet-worker/pull/860

This change helps import the Visual Studio design time targets to the Azure Functions SDK. This helps enable functionality like - File Nesting, Debug property page options, other project system settings etc.

/cc @BillHiebert