### PR TITLE
[Build]Switching from EsrpCodeSigning@1 to EsrpCodeSigning@2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ steps:
       test\**\Microsoft.NET.Sdk.Functions.Generator.Tests.csproj
       test\**\Microsoft.NET.Sdk.Functions.MSBuild.Tests.csproj
       test\**\Microsoft.NET.Sdk.Functions.EndToEnd.Tests.csproj
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
   displayName: 'ESRP CodeSigning'
   inputs:
     ConnectedServiceName: 'ESRP Service'
@@ -86,7 +86,7 @@ steps:
             "ToolVersion": "1.0"
           }
         ]
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
   displayName: 'ESRP CodeSigning: Third party'
   inputs:
     ConnectedServiceName: 'ESRP Service'
@@ -128,7 +128,7 @@ steps:
     arguments: '--no-build -c Release -o artifacts'
     projects: |
       **\Microsoft.Net.Sdk.Functions.csproj
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
   displayName: 'ESRP CodeSigning: Nupkg'
   inputs:
     ConnectedServiceName: 'ESRP Service'


### PR DESCRIPTION
Currently the [codesigning task is failing](https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=160325&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=094908eb-9b91-5864-e5bc-10e3f5697105) as it requires 'Microsoft.NETCore.App', version '2.1.0 framework and looks like the agents does not have that anymore.  To fix this we are  switching from EsrpCodeSigning@1 to EsrpCodeSigning@2 which apparently relies on a newer version of the framework which exists in these agents.

Sample run using this PR branch - Code signing step does not fail- https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=160326&view=results