### PR TITLE
Enabling multiple TFMs / tooling suffixes

### DIFF
--- a/common.props
+++ b/common.props
@@ -3,7 +3,7 @@
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">true</ContinuousIntegrationBuild>
 
     <MajorProductVersion>4</MajorProductVersion>
-    <MinorProductVersion>3</MinorProductVersion>
+    <MinorProductVersion>4</MinorProductVersion>
     <PatchProductVersion>0</PatchProductVersion>
 
     <!-- Clear this value for non-preview releases -->

--- a/src/Microsoft.NET.Sdk.Functions.Generator/Microsoft.NET.Sdk.Functions.Generator.csproj
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/Microsoft.NET.Sdk.Functions.Generator.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
   </PropertyGroup>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
@@ -24,10 +24,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <_ToolingSuffix></_ToolingSuffix>
     <_ToolingSuffix Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">net8-in-process</_ToolingSuffix>
-    <_ToolingSuffix Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">net6-in-process</_ToolingSuffix>
   	<AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">v0</AzureFunctionsVersion>
-    <AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">v4</AzureFunctionsVersion>
-    <AzureFunctionsVersion>$(AzureFunctionsVersion)$(ReleaseQuality)</AzureFunctionsVersion>
     <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
   </PropertyGroup>
 

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
@@ -21,6 +21,12 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == '' and '$(IsPackable)' == 'false'">true</WarnOnPackingNonPackableProject>
     <IsZipDeploySupported>true</IsZipDeploySupported>
     <MSBuildFunctionsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed.Functions\</MSBuildFunctionsTargetsPath>
+
+	<_ToolingSuffix></_ToolingSuffix>
+	<_ToolingSuffix Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">net8-in-process</_ToolingSuffix>
+	<AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">v0</AzureFunctionsVersion>
+
+	<FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
   </PropertyGroup>
 
   <UsingTask TaskName="GenerateFunctions"

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
@@ -12,7 +12,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <_FunctionsTaskFramework>net6.0</_FunctionsTaskFramework>
+    <_FunctionsTaskFramework>$(TargetFramework)</_FunctionsTaskFramework>
     <_FunctionsTasksDir Condition=" '$(_FunctionsTasksDir)'=='' ">$(MSBuildThisFileDirectory)..\tools\$(_FunctionsTaskFramework)\</_FunctionsTasksDir>
     <_FunctionsTaskAssemblyFullPath Condition=" '$(_FunctionsTaskAssemblyFullPath)'=='' ">$(_FunctionsTasksDir)\Microsoft.NET.Sdk.Functions.MSBuild.dll</_FunctionsTaskAssemblyFullPath>
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
@@ -22,11 +22,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <IsZipDeploySupported>true</IsZipDeploySupported>
     <MSBuildFunctionsTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed.Functions\</MSBuildFunctionsTargetsPath>
 
-	<_ToolingSuffix></_ToolingSuffix>
-	<_ToolingSuffix Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">net8-in-process</_ToolingSuffix>
-	<AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">v0</AzureFunctionsVersion>
+    <_ToolingSuffix></_ToolingSuffix>
+    <_ToolingSuffix Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">net8-in-process</_ToolingSuffix>
+    <AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">v0</AzureFunctionsVersion>
+    <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
 
-	<FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
   </PropertyGroup>
 
   <UsingTask TaskName="GenerateFunctions"

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
@@ -24,9 +24,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <_ToolingSuffix></_ToolingSuffix>
     <_ToolingSuffix Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">net8-in-process</_ToolingSuffix>
-    <AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">v0</AzureFunctionsVersion>
-    <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
-
+	<AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">v0$(ReleaseQuality)</AzureFunctionsVersion>
+    <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>    
   </PropertyGroup>
 
   <UsingTask TaskName="GenerateFunctions"
@@ -88,7 +87,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <Target Name="_InitializeFunctionsSdk">
     <Warning Text="The ExtensionsMetadataGenerator package was not imported correctly. Are you missing '$(_ExtensionsMetadataGeneratorTargetsPath)' or '$(_ExtensionsMetadataGeneratorPropsPath)'?"
              Condition="!$(AzureFunctionsVersion.StartsWith('v1')) And ('$(_ExtensionsMetadataGeneratorTargetsImported)' == '' Or '$(_ExtensionsMetadataGeneratorPropsImported)' == '')" />
-   
+
     <GetAssemblyIdentity AssemblyFiles="$(_FunctionsTaskAssemblyFullPath)">
         <Output
             TaskParameter="Assemblies"

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
@@ -24,8 +24,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <_ToolingSuffix></_ToolingSuffix>
     <_ToolingSuffix Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">net8-in-process</_ToolingSuffix>
-	<AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">v0$(ReleaseQuality)</AzureFunctionsVersion>
-    <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>    
+    <_ToolingSuffix Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">net6-in-process</_ToolingSuffix>
+  	<AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">v0</AzureFunctionsVersion>
+    <AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v6.0'">v4</AzureFunctionsVersion>
+    <AzureFunctionsVersion>$(AzureFunctionsVersion)$(ReleaseQuality)</AzureFunctionsVersion>
+    <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
   </PropertyGroup>
 
   <UsingTask TaskName="GenerateFunctions"

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.targets
@@ -24,8 +24,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <_ToolingSuffix></_ToolingSuffix>
     <_ToolingSuffix Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">net8-in-process</_ToolingSuffix>
-  	<AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0'">v0</AzureFunctionsVersion>
     <FunctionsToolingSuffix Condition="'$(FunctionsToolingSuffix)' == ''">$(_ToolingSuffix)</FunctionsToolingSuffix>
+    <AzureFunctionsVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion)' == 'v8.0' And $(AzureFunctionsVersion.StartsWith('v4'))">$(AzureFunctionsVersion.Replace("v4","v0"))</AzureFunctionsVersion>
   </PropertyGroup>
 
   <UsingTask TaskName="GenerateFunctions"

--- a/src/Microsoft.NET.Sdk.Functions/Microsoft.NET.Sdk.Functions.csproj
+++ b/src/Microsoft.NET.Sdk.Functions/Microsoft.NET.Sdk.Functions.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\common.props"/>
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <PackageName>Microsoft.NET.Sdk.Functions</PackageName>
     <Authors>Microsoft</Authors>
     <ProjectUrl>https://github.com/Azure/azure-functions-vs-build-sdk</ProjectUrl>
@@ -36,8 +36,13 @@
       <PackagePath>tools\net6.0\</PackagePath>
       <Visible>false</Visible>
     </None>
-
-    <!-- Generator and dependent assemblies-->
+    <None Include="$(FunctionsBuildTaskOutputPath)\netstandard2.0\Microsoft.NET.Sdk.Functions.MSBuild.dll">
+      <Pack>true</Pack>
+      <PackagePath>tools\net8.0\</PackagePath>
+      <Visible>false</Visible>
+    </None>	
+		
+	  <!-- Generator and dependent assemblies-->
     <None Include="$(FunctionsGeneratorOutputPath)\net6.0\Newtonsoft.Json.dll">
       <Pack>true</Pack>
       <PackagePath>tools\net6.0\</PackagePath>
@@ -58,6 +63,26 @@
       <PackagePath>tools\net6.0\</PackagePath>
       <Visible>false</Visible>
     </None>
+	<None Include="$(FunctionsGeneratorOutputPath)\net8.0\Newtonsoft.Json.dll">
+	  <Pack>true</Pack>
+	  <PackagePath>tools\net8.0\</PackagePath>
+	  <Visible>false</Visible>
+	</None>
+	<None Include="$(FunctionsGeneratorOutputPath)\net8.0\Mono.Cecil.dll">
+	  <Pack>true</Pack>
+	  <PackagePath>tools\net8.0\</PackagePath>
+	  <Visible>false</Visible>
+	</None>
+	<None Include="$(FunctionsGeneratorOutputPath)\net8.0\Microsoft.NET.Sdk.Functions.Generator.dll">
+	  <Pack>true</Pack>
+	  <PackagePath>tools\net8.0\</PackagePath>
+	  <Visible>false</Visible>
+	</None>
+	<None Include="$(FunctionsGeneratorOutputPath)\net8.0\Microsoft.NET.Sdk.Functions.Generator.runtimeconfig.json">
+	  <Pack>true</Pack>
+	  <PackagePath>tools\net8.0\</PackagePath>
+	  <Visible>false</Visible>
+	</None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates to support .NET 8 builds in the future, in alignment with upcoming tooling feed changes.

This takes inspiration from what's done in the isolated worker mode. However, note that the conditions here are just based on TFM. This will override AzureFunctionsVersion, which should be perfectly fine here.