### PR TITLE
[1ES] Add code mirror

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -1,0 +1,21 @@
+trigger:
+  branches:
+    include:
+    # Keep this set limited as appropriate (don't mirror individual user branches).
+    - main
+    - release/*
+    - v3.x
+    - v4.x
+
+resources:
+  repositories:
+  - repository: eng
+    type: git
+    name: engineering
+    ref: refs/tags/release
+
+variables:
+  - template: ci/variables/cfs.yml@eng
+
+extends:
+  template: ci/code-mirror.yml@eng


### PR DESCRIPTION
This PR introduces a new pipeline 'code-mirror' which is part of our 1ES efforts. The pipeline is responsible for mirroring changes to github branches into an internal Azure Devops copy of this repository.