### PR TITLE
Remove myget reference from nuget config

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -5,7 +5,6 @@ trigger:
     - main
     - release/*
     - v3.x
-    - v4.x
 
 resources:
   repositories:

--- a/nuget.config
+++ b/nuget.config
@@ -2,5 +2,7 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />    
+    <add key="azure-appservice-test" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/azure-appservice-test%40Local/nuget/v3/index.json" />
+    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />    
-    <add key="azure_app_service_staging" value="https://www.myget.org/F/azure-appservice-staging/api/v2" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />    
     <add key="azure-appservice-test" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/azure-appservice-test%40Local/nuget/v3/index.json" />
     <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />


### PR DESCRIPTION
- Removed myget reference from nuget config as that is not allowed as per policy
- Added `<clear />` element in nuget config
- Updating code-mirror file to remove v4.x branch as that should not be mirrored.