### PR TITLE
4.4.1 - Fixing NRE in IsWebJobsAttribute

### DIFF
--- a/common.props
+++ b/common.props
@@ -4,7 +4,7 @@
 
     <MajorProductVersion>4</MajorProductVersion>
     <MinorProductVersion>4</MinorProductVersion>
-    <PatchProductVersion>0</PatchProductVersion>
+    <PatchProductVersion>1</PatchProductVersion>
 
     <!-- Clear this value for non-preview releases -->
     <PreviewProductVersion></PreviewProductVersion>

--- a/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
@@ -43,13 +43,13 @@ namespace MakeFunctionJson
          };
 
         /// <summary>
-        ///
+        /// Checks if a custom attribute is a WebJobs attribute.
         /// </summary>
-        /// <param name="attribute"></param>
-        /// <returns></returns>
+        /// <param name="attribute">The custom attribute to check.</param>
+        /// <returns>True if the attribute is a WebJobs attribute; otherwise, False.</returns>
         public static bool IsWebJobsAttribute(this CustomAttribute attribute)
         {
-            var attributeTypeDefinition = attribute.AttributeType.Resolve();
+            var attributeTypeDefinition = attribute.AttributeType?.Resolve();
 
             if (attributeTypeDefinition == null)
             {

--- a/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/AttributeExtensions.cs
@@ -49,7 +49,14 @@ namespace MakeFunctionJson
         /// <returns></returns>
         public static bool IsWebJobsAttribute(this CustomAttribute attribute)
         {
-            return attribute.AttributeType.Resolve().CustomAttributes.Any(a => a.AttributeType.FullName == "Microsoft.Azure.WebJobs.Description.BindingAttribute")
+            var attributeTypeDefinition = attribute.AttributeType.Resolve();
+
+            if (attributeTypeDefinition == null)
+            {
+                return false;
+            }
+
+            return attributeTypeDefinition.CustomAttributes.Any(a => a.AttributeType.FullName == "Microsoft.Azure.WebJobs.Description.BindingAttribute")
                 || _supportedAttributes.Contains(attribute.AttributeType.FullName);
         }
 

--- a/test/Microsoft.NET.Sdk.Functions.EndToEnd.Tests/FunctionsV4SdkTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.EndToEnd.Tests/FunctionsV4SdkTests.cs
@@ -11,11 +11,11 @@ namespace Microsoft.NET.Sdk.Functions.EndToEnd.Tests
         private string _testsDirectory;
         private TestInitialize _testInitializer;
         private ITestOutputHelper _testOutputHelper;
-        private const string _testVersion = "v4";
+        private const string TestVersion = "v4";
 
         public FunctionsV4SdkTests(ITestOutputHelper testOutputHelper)
         {
-            _testInitializer = new TestInitialize(testOutputHelper, _testVersion);
+            _testInitializer = new TestInitialize(testOutputHelper, TestVersion);
             _testOutputHelper = testOutputHelper;
             _functionsSdkPackageSource = _testInitializer.FunctionsSdkPackageSource;
             _testsDirectory = _testInitializer.TestDirectory;
@@ -68,7 +68,7 @@ namespace Microsoft.NET.Sdk.Functions.EndToEnd.Tests
             Assert.True(Directory.Exists(additionalBinDir));
             var files = Directory.EnumerateFiles(additionalBinDir, "*.dll", SearchOption.AllDirectories);
             Assert.True(files.Count() > 1);
-            // Test addional runtimes
+            // Test additional runtimes
             files = Directory.EnumerateFiles(Path.Combine(additionalBinDir, "runtimes"), "*.dll", SearchOption.AllDirectories);
             Assert.True(files.Count() > 1);
 
@@ -99,7 +99,7 @@ namespace Microsoft.NET.Sdk.Functions.EndToEnd.Tests
             string dotnetArgs = $"build {projectFileToTest}.csproj --configuration {TestInitialize.Configuration}";
             int? exitCode = new ProcessWrapper().RunProcess(TestInitialize.DotNetExecutable, dotnetArgs, projectFileDirectory, out int? _, createDirectoryIfNotExists: false, testOutputHelper: _testOutputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
-            // Test addional bin
+            // Test additional bin
             string binDir = Path.Combine(projectFileDirectory, "bin", TestInitialize.Configuration, TestInitialize.NetCoreFramework);
             string additionalBinDir = Path.Combine(binDir, "bin");
             Assert.True(Directory.Exists(additionalBinDir));
@@ -108,6 +108,8 @@ namespace Microsoft.NET.Sdk.Functions.EndToEnd.Tests
             // Test functions generator output
             string httpTriggerFunctionpath = Path.Combine(binDir, "HttpFunction", "function.json");
             Assert.True(File.Exists(httpTriggerFunctionpath));
+            string httpTrigger2Functionpath = Path.Combine(binDir, "HttpFunction2", "function.json");
+            Assert.True(File.Exists(httpTrigger2Functionpath));
 
             // Publish
             dotnetArgs = $"publish {projectFileToTest}.csproj --configuration {TestInitialize.Configuration}";
@@ -122,6 +124,8 @@ namespace Microsoft.NET.Sdk.Functions.EndToEnd.Tests
             // Test functions generator output
             httpTriggerFunctionpath = Path.Combine(publishDir, "HttpFunction", "function.json");
             Assert.True(File.Exists(httpTriggerFunctionpath));
+            httpTrigger2Functionpath = Path.Combine(publishDir, "HttpFunction2", "function.json");
+            Assert.True(File.Exists(httpTrigger2Functionpath));
         }
 
         private void UpdatePackageReference(string projectFileToTest, string projectFileDirectory)

--- a/test/Microsoft.NET.Sdk.Functions.EndToEnd.Tests/Resources/v4/FunctionAppWithHttpTrigger/HttpFunction.cs
+++ b/test/Microsoft.NET.Sdk.Functions.EndToEnd.Tests/Resources/v4/FunctionAppWithHttpTrigger/HttpFunction.cs
@@ -31,5 +31,13 @@ namespace FunctionApp1
 
             return new OkObjectResult(responseMessage);
         }
+
+        // A function which uses nullable type for parameter.
+        [FunctionName("HttpFunction2")]
+        public static async Task<IActionResult> Run2(
+            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = "hello/{id}")] HttpRequest req, ILogger log, string? id)
+        {
+            return new OkObjectResult($"Hello {id}");
+        }
     }
 }


### PR DESCRIPTION
Fixes #641 

- Adding null check to the result of `attribute.AttributeType?.Resolve()` in `IsWebJobsAttribute` method, before calling other methods on the result of that.
- Bumped patch version (new version is 4.4.1)
--------------------------------------------------------------------------
I also investigated the reason why the `Resolve` method was returning null when using nullable parameter.

The problem arises when the function parameter is nullable (e.g., `string? id`) in an in-process .NET 8.0 application. In such cases, the `IsWebJobsAttribute` method is called for `System.Runtime.CompilerServices.NullableAttribute`, and the `attribute.AttributeType.Resolve()` expression returns null, leading to a NullReferenceException.

This code is executed from `Microsoft.NET.Sdk.Functions.Generator`, which we start from the .NET 6.0 output (relevant code [here](https://github.com/Azure/azure-functions-vs-build-sdk/blob/03a17c828378121e418db235e0051ebfa1e31a73/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/GenerateFunctions.cs#L26)). This causes the .NET 6 version of the `System.Runtime` module (among others) to be loaded. The `NullableAttribute` is not available in .NET 6, causing the `Resolve` method to return null. Discussed this with the team and we agreed that returning false when Resolve returns null is good enough to address the issue.