### PR TITLE
Fuction App Flex Consumption publish support

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/Resources.Designer.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Sdk.Functions.MSBuild.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -75,6 +75,15 @@ namespace Microsoft.NET.Sdk.Functions.MSBuild.Properties {
         internal static string DeploymentStatusPolling {
             get {
                 return ResourceManager.GetString("DeploymentStatusPolling", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deployment status is {0}: {1}.
+        /// </summary>
+        internal static string DeploymentStatusWithText {
+            get {
+                return ResourceManager.GetString("DeploymentStatusWithText", resourceCulture);
             }
         }
         

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/Resources.resx
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Properties/Resources.resx
@@ -144,4 +144,8 @@
   <data name="ZipFileUploaded" xml:space="preserve">
     <value>Uploaded the Zip file to the target.</value>
   </data>
+  <data name="DeploymentStatusWithText" xml:space="preserve">
+    <value>Deployment status is {0}: {1}</value>
+    <comment>0 - name, 1 - text message</comment>
+  </data>
 </root>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.ZipDeploy.targets
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.ZipDeploy.targets
@@ -49,7 +49,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       DeploymentPassword="$(Password)"
       SiteName="$(DeployIisAppPath)"
       PublishUrl="$(PublishUrl)"
-      UserAgentVersion="$(ZipDeployUserAgent)"/>
+      UserAgentVersion="$(ZipDeployUserAgent)"
+      UseBlobContainerDeploy="$(UseBlobContainerDeploy)"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/ZipDeployTask.cs
+++ b/src/Microsoft.NET.Sdk.Functions.MSBuild/Tasks/ZipDeployTask.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -30,6 +29,7 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
 
         public string PublishUrl { get; set; }
 
+        public bool UseBlobContainerDeploy { get; set; }
 
         /// <summary>
         /// Our fallback if PublishUrl is not given, which is the case for ZIP Deploy profiles created prior to 15.8 Preview 4.
@@ -41,13 +41,18 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
         { 
             using(DefaultHttpClient client = new DefaultHttpClient())
             {
-                System.Threading.Tasks.Task<bool> t = ZipDeployAsync(ZipToPublishPath, DeploymentUsername, DeploymentPassword, PublishUrl, SiteName, UserAgentVersion, client, true);
+                System.Threading.Tasks.Task<bool> t = ZipDeployAsync(ZipToPublishPath, DeploymentUsername, DeploymentPassword, PublishUrl, SiteName, UserAgentVersion, UseBlobContainerDeploy, client, logMessages: true);
                 t.Wait();
                 return t.Result;
             }
         }
 
-        internal async System.Threading.Tasks.Task<bool> ZipDeployAsync(string zipToPublishPath, string userName, string password, string publishUrl, string siteName, string userAgentVersion, IHttpClient client, bool logMessages)
+        internal System.Threading.Tasks.Task<bool> ZipDeployAsync(string zipToPublishPath, string userName, string password, string publishUrl, string siteName, string userAgentVersion, IHttpClient client, bool logMessages)
+        {
+            return ZipDeployAsync(zipToPublishPath, userName, password, publishUrl, siteName, userAgentVersion, useBlobContainerDeploy: false, client, logMessages);
+        }
+
+        internal async System.Threading.Tasks.Task<bool> ZipDeployAsync(string zipToPublishPath, string userName, string password, string publishUrl, string siteName, string userAgentVersion, bool useBlobContainerDeploy, IHttpClient client, bool logMessages)
         {
             if (!File.Exists(zipToPublishPath) || client == null)
             {
@@ -62,11 +67,11 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
                     publishUrl += "/";
                 }
 
-                zipDeployPublishUrl = publishUrl + "api/zipdeploy";
+                zipDeployPublishUrl = publishUrl + "api";
             }
             else if(!string.IsNullOrEmpty(siteName))
             {
-                zipDeployPublishUrl = $"https://{siteName}.scm.azurewebsites.net/api/zipdeploy";
+                zipDeployPublishUrl = $"https://{siteName}.scm.azurewebsites.net/api";
             }
             else
             {
@@ -77,6 +82,12 @@ namespace Microsoft.NET.Sdk.Functions.Tasks
 
                 return false;
             }
+
+            // publish endpoint differs when using a blob storage container
+            var publishUriPath = useBlobContainerDeploy ? "publish" : "zipdeploy";
+
+            // "<publishUrl>/api/zipdeploy" or "<publishUrl>/api/publish"
+            zipDeployPublishUrl = $"{zipDeployPublishUrl}/{publishUriPath}";
 
             if (logMessages)
             {

--- a/test/Microsoft.NET.Sdk.Functions.MSBuild.Tests/ZipDeploymentStatusTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.MSBuild.Tests/ZipDeploymentStatusTests.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.NET.Sdk.Functions.Http;
-using Microsoft.NET.Sdk.Functions.MSBuild.Properties;
 using Microsoft.NET.Sdk.Functions.MSBuild.Tasks;
 using Moq;
 using Newtonsoft.Json;
@@ -55,13 +54,13 @@ namespace Microsoft.NET.Sdk.Functions.MSBuild.Tests
         }
 
         [Theory]
-        [InlineData(HttpStatusCode.OK, DeployStatus.Success)]
-        [InlineData(HttpStatusCode.Accepted, DeployStatus.Success)]
-        [InlineData(HttpStatusCode.OK, DeployStatus.Failed)]
-        [InlineData(HttpStatusCode.Accepted, DeployStatus.Failed)]
-        [InlineData(HttpStatusCode.OK, DeployStatus.Unknown)]
-        [InlineData(HttpStatusCode.Accepted, DeployStatus.Unknown)]
-        public async Task PollDeploymentStatusTest_ForValidResponses(HttpStatusCode responseStatusCode, DeployStatus expectedDeployStatus)
+        [InlineData(HttpStatusCode.OK, "", DeployStatus.Success)]
+        [InlineData(HttpStatusCode.Accepted, null, DeployStatus.Success)]
+        [InlineData(HttpStatusCode.OK, "Instance configuration is not valid", DeployStatus.Failed)]
+        [InlineData(HttpStatusCode.Accepted, "", DeployStatus.Failed)]
+        [InlineData(HttpStatusCode.OK, null, DeployStatus.Unknown)]
+        [InlineData(HttpStatusCode.Accepted, null, DeployStatus.Unknown)]
+        public async Task PollDeploymentStatusTest_ForValidResponses(HttpStatusCode responseStatusCode, string statusMessage, DeployStatus expectedDeployStatus)
         {
             // Arrange
             string deployUrl = "https://sitename.scm.azurewebsites.net/DeploymentStatus?Id=knownId";
@@ -80,7 +79,8 @@ namespace Microsoft.NET.Sdk.Functions.MSBuild.Tests
             {
                 string statusJson = JsonConvert.SerializeObject(new
                 {
-                    status = Enum.GetName(typeof(DeployStatus), expectedDeployStatus)
+                    status = Enum.GetName(typeof(DeployStatus), expectedDeployStatus),
+                    status_text = statusMessage
                 }, Formatting.Indented);
 
                 HttpContent httpContent = new StringContent(statusJson, Encoding.UTF8, "application/json");


### PR DESCRIPTION
Add support to publish a Function App Flex through ZipDeploy

- Add new `UseBlobContainerDeploy` (`bool`) property to the ZipDeploy target/task to identify when to use the
`"<publishUrl>/api/publish"` endpoint to publish a Flex Consumption function app

- When polling for the ZipDeploy pubish status, append the `status_text` message (if defined) along with the status itself. E.g.: `"Deployment status is Failed: App setting WEBSITE_RUN_FROM_PACKAGE is not supported..."`.

- Update/add UTs

Change in `azure-functions-dotnet-worker`: [Fuction App Flex Consumption publish support #2688](https://github.com/Azure/azure-functions-dotnet-worker/pull/2688)