### PR TITLE
Fix Reference to ExtensionsMetadataGenerator

### DIFF
--- a/FunctionsSdkE2ETests/SdkVersion.props
+++ b/FunctionsSdkE2ETests/SdkVersion.props
@@ -1,4 +1,4 @@
-<Project>  
+<Project>
   <PropertyGroup>
     <!-- These are the latest SDK versions -->
     <MicrosoftNetSdkFunctionsV4Version>4.5.0</MicrosoftNetSdkFunctionsV4Version>
@@ -7,6 +7,6 @@
     <MicrosoftNetSdkFunctionsV4PreviousVersion>4.4.1</MicrosoftNetSdkFunctionsV4PreviousVersion>
 
     <!-- Some tests directly reference EMG; this should be latest -->
-    <ExtensionsMetadataGeneratorDirectReferenceVersion>4.5.0</ExtensionsMetadataGeneratorDirectReferenceVersion>
+    <ExtensionsMetadataGeneratorDirectReferenceVersion>4.0.1</ExtensionsMetadataGeneratorDirectReferenceVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fix failing test/build [here](https://azfunc.visualstudio.com/public/_build/results?buildId=186980&view=logs&j=64340cd7-31c9-5f4e-1c09-a537a0d43227&t=ce0303b1-1a6e-522e-5e2b-432947ea7ded), use latest version [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator/).