### PR TITLE
Fixing README logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿![Azure Functions Logo](https://raw.githubusercontent.com/Azure/azure-functions-cli/master/src/Azure.Functions.Cli/npm/assets/azure-functions-logo-color-raster.png)
+﻿![Azure Functions Logo](https://raw.githubusercontent.com/Azure/azure-functions-cli/main/eng/res/functions.png)
 
 |Branch|Status|
 |---|---|


### PR DESCRIPTION
Applying the same fix that was made in https://github.com/Azure/azure-functions-host/pull/11211.

I see now that there are 11 other instances of this across Functions repos. See Azure query: https://github.com/search?q=org%3AAzure%20master%2Fsrc%2FAzure.Functions.Cli%2Fnpm%2Fassets%2Fazure-functions-logo-color-raster.png&type=code. I've created work item https://github.com/Azure/azure-functions-core-tools/issues/4624 to track fixing these.