### PR TITLE
Onboard dependency restores to CFS

### DIFF
--- a/FunctionsSdkE2ETests/nuget.config
+++ b/FunctionsSdkE2ETests/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />    
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,8 @@ steps:
       # Official release versions can be found at: https://dotnet.microsoft.com/download/dotnet/6.0
       # Newer versions can be found at: https://github.com/dotnet/installer#installers-and-binaries
       ./dotnet-install.ps1 -InstallDir 'C:\Program Files\dotnet' -Verbose -Version 6.0.101
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate NuGet feeds'
 - task: DotNetCoreCLI@2
   displayName: 'Build'
   inputs:

--- a/eng/ci/templates/jobs/build-and-test.yml
+++ b/eng/ci/templates/jobs/build-and-test.yml
@@ -22,6 +22,9 @@ jobs:
     inputs:
       version: 6.x
 
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feeds
+
   - task: DotNetCoreCLI@2
     displayName: 'Build'
     inputs:

--- a/nuget.config
+++ b/nuget.config
@@ -2,8 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />    
-    <add key="azure-appservice-test" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/azure-appservice-test%40Local/nuget/v3/index.json" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,4 @@
-source https://nuget.org/api/v2
-source https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/azure-appservice-test%40Local/nuget/v3/index.json
-source https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json
+source https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json
 
 nuget FAKE
 nuget WindowsAzure.Storage = 9.3.1

--- a/paket.lock
+++ b/paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json
     FAKE (4.64.10)
     Microsoft.Azure.KeyVault.Core (2.0.4) - restriction: || (>= net45) (>= wp8)
     Microsoft.CSharp (4.5) - restriction: || (&& (< net20) (>= net45) (>= netstandard1.3) (< netstandard2.0)) (&& (< net20) (>= net45) (< netstandard1.3)) (&& (< net20) (>= netstandard1.0) (< netstandard1.3) (< win8)) (&& (< net20) (>= netstandard1.3) (< netstandard2.0) (< win8)) (&& (< netstandard1.0) (>= netstandard1.3) (>= win8)) (&& (>= netstandard1.3) (< netstandard2.0) (>= wpa81)) (&& (< netstandard1.3) (>= wpa81)) (>= wp8)

--- a/test/Microsoft.NET.Sdk.Functions.EndToEnd.Tests/FunctionsV4SdkTests.cs
+++ b/test/Microsoft.NET.Sdk.Functions.EndToEnd.Tests/FunctionsV4SdkTests.cs
@@ -131,16 +131,16 @@ namespace Microsoft.NET.Sdk.Functions.EndToEnd.Tests
         private void UpdatePackageReference(string projectFileToTest, string projectFileDirectory)
         {
             // Update package
-            string dotnetArgs = $"remove {projectFileToTest}.csproj package {TestInitialize.FunctionsNetSdkProject}";
+            string dotnetArgs = $"remove \"{projectFileToTest}.csproj\" package {TestInitialize.FunctionsNetSdkProject}";
             int? exitCode = new ProcessWrapper().RunProcess(TestInitialize.DotNetExecutable, dotnetArgs, projectFileDirectory, out int? _, createDirectoryIfNotExists: false, testOutputHelper: _testOutputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
 
-            dotnetArgs = $"add {projectFileToTest}.csproj package {TestInitialize.FunctionsNetSdkProject} --source {TestInitialize.NuGetPackageSource} --prerelease --no-restore";
+            dotnetArgs = $"add \"{projectFileToTest}.csproj\" package {TestInitialize.FunctionsNetSdkProject} --source \"{TestInitialize.NuGetPackageSource}\" --prerelease --no-restore";
             exitCode = new ProcessWrapper().RunProcess(TestInitialize.DotNetExecutable, dotnetArgs, projectFileDirectory, out int? _, createDirectoryIfNotExists: false, testOutputHelper: _testOutputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
 
             // Restore
-            dotnetArgs = $"restore {projectFileToTest}.csproj --source {TestInitialize.NuGetPackageSource};{_functionsSdkPackageSource}";
+            dotnetArgs = $"restore \"{projectFileToTest}.csproj\" --source \"{TestInitialize.NuGetPackageSource}\" --source \"{_functionsSdkPackageSource}\"";
             exitCode = new ProcessWrapper().RunProcess(TestInitialize.DotNetExecutable, dotnetArgs, projectFileDirectory, out int? _, createDirectoryIfNotExists: false, testOutputHelper: _testOutputHelper);
             Assert.True(exitCode.HasValue && exitCode.Value == 0);
         }

--- a/test/Microsoft.NET.Sdk.Functions.EndToEnd.Tests/TestInitialize.cs
+++ b/test/Microsoft.NET.Sdk.Functions.EndToEnd.Tests/TestInitialize.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Sdk.Functions.EndToEnd.Tests
         public const string NetStandard = "netstandard2.0";
 
         // NuGet Sources
-        public const string NuGetPackageSource = @"https://api.nuget.org/v3/index.json";
+        public const string NuGetPackageSource = @"https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json";
         // Paths and executables
         public static readonly string DotNetExecutable = "dotnet";
         public static readonly string MSBuildExecutable = "msbuild.exe";


### PR DESCRIPTION
## Summary
- route NuGet and Paket dependency resolution through the CFS upstream-public feed
- remove legacy nuget.org and Azure Artifacts package sources from repository build paths
- authenticate NuGet before restore-capable Azure Pipelines tasks
- update end-to-end test package resolution to use CFS

## Validation
- dotnet restore FunctionsSdk.sln --force --no-cache
- dotnet restore FunctionsSdkE2ETests\FunctionsSdkE2ETests.sln --force --no-cache
- dotnet build test\Microsoft.NET.Sdk.Functions.EndToEnd.Tests\Microsoft.NET.Sdk.Functions.EndToEnd.Tests.csproj --no-restore --configuration Debug